### PR TITLE
Updated example deviceconfig name

### DIFF
--- a/example/deviceconfig_example.yaml
+++ b/example/deviceconfig_example.yaml
@@ -1,7 +1,8 @@
 apiVersion: amd.com/v1alpha1
 kind: DeviceConfig
 metadata:
-  name: test-deviceconfig
+  # the names for the device plugin, metrics exporter and node labeler pods will be prefixed with this name
+  name: gpu-operator
   # it is highly recommended to use the namespace where AMD GPU Operator is running
   namespace: kube-amd-gpu
 spec:


### PR DESCRIPTION
Updated the name in the deviceconfig example file and added note to tell users that the device plugin, metrics exporter and node labeler pods will be prefixed with this name