### PR TITLE
Update quick start in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,15 @@ helm install cert-manager jetstack/cert-manager \
 
 ## Quick Start
 
+Add the Helm repository:
 ```bash
-helm install amd-gpu-operator --namespace kube-amd-gpu --create-namespace https://github.com/ROCm/gpu-operator/releases/download/v1.0.0/gpu-operator-charts-v1.0.0.tgz
+helm repo add rocm https://rocm.github.io/gpu-operator
+helm repo update
+```
+
+Install the AMD GPU Operator:
+```bash
+helm install amd-gpu-operator rocm/gpu-operator-charts --namespace kube-amd-gpu --create-namespace
 ```
 
 ### Grafana Dashboards

--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ helm install cert-manager jetstack/cert-manager \
 ## Quick Start
 
 Add the Helm repository:
+
 ```bash
 helm repo add rocm https://rocm.github.io/gpu-operator
 helm repo update
 ```
 
 Install the AMD GPU Operator:
+
 ```bash
 helm install amd-gpu-operator rocm/gpu-operator-charts --namespace kube-amd-gpu --create-namespace
 ```


### PR DESCRIPTION
The quick start for installing the operator is out of data, and doesn't match AMD docs. This PR will update the readme to match the docs for the quick start. 