### PR TITLE
use package power metrics

### DIFF
--- a/grafana/dashboard_gpu.json
+++ b/grafana/dashboard_gpu.json
@@ -14,13 +14,6 @@
       "description": "",
       "type": "datasource",
       "pluginId": "__expr__"
-    },
-    {
-      "name": "VAR_G_MI300_MODEL",
-      "type": "constant",
-      "label": "MI300 Model",
-      "value": "102-G30211-00",
-      "description": ""
     }
   ],
   "__elements": {},
@@ -40,7 +33,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.2.2+security-01"
+      "version": "11.2.2"
     },
     {
       "type": "datasource",
@@ -108,10 +101,10 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "#### VENDOR\n${g_card_vendor}\n\n#### SERIES\n${g_card_series}\n\n#### MODEL\n${g_card_model}\n\n#### SERIAL\n${g_serial_number}",
+        "content": "##### VENDOR\n${g_card_vendor}\n\n##### SERIES\n${g_card_series}\n\n##### MODEL\n${g_card_model}\n\n##### SERIAL\n${g_serial_number}\n\n##### UUID\n${g_gpu_uuid}",
         "mode": "markdown"
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -130,7 +123,6 @@
           "useBackend": false
         }
       ],
-      "title": "Device",
       "type": "text"
     },
     {
@@ -154,7 +146,7 @@
         "content": "#### HOST\n${g_hostname}\n\n#### GPU ID\n${g_gpu_id}",
         "mode": "markdown"
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "type": "text"
     },
     {
@@ -162,7 +154,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "GPU current power",
+      "description": "GPU package power usage",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -178,7 +170,7 @@
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 700
               }
             ]
           },
@@ -208,7 +200,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -218,17 +210,35 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "gpu_package_power{gpu_uuid=\"$g_gpu_uuid\", hostname=\"$g_hostname\"}",
+          "expr": "gpu_average_package_power{gpu_uuid=\"$g_gpu_uuid\", hostname=\"$g_hostname\"}",
           "fullMetaSearch": false,
+          "hide": false,
           "includeNullMetadata": true,
           "instant": false,
           "legendFormat": "{{hostname}}[{{gpu_id}}]",
           "range": true,
           "refId": "A",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "gpu_package_power{gpu_uuid=\"$g_gpu_uuid\", hostname=\"$g_hostname\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{hostname}}[{{gpu_id}}]",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
         }
       ],
-      "title": "GPU Package Power",
+      "title": "GPU Power Usage",
       "transformations": [
         {
           "id": "calculateField",
@@ -294,7 +304,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -381,7 +391,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -527,7 +537,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -708,7 +718,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -779,7 +789,7 @@
         "content": "#### VBIOS\n${g_gpu_vbios}\n\n#### DRIVER\n${g_driver}",
         "mode": "markdown"
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "title": "Software",
       "type": "text"
     },
@@ -833,7 +843,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -907,7 +917,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -984,7 +994,7 @@
         "textMode": "value",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -1348,7 +1358,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "gpu_package_power{gpu_uuid=\"$g_gpu_uuid\"}",
+          "expr": "gpu_package_power{gpu_uuid=\"$g_gpu_uuid\", card_model=~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1356,9 +1366,22 @@
           "range": true,
           "refId": "A",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "gpu_average_package_power{gpu_uuid=\"$g_gpu_uuid\", card_model!~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "GPU Power",
+      "title": "GPU Package Power",
       "type": "timeseries"
     },
     {
@@ -1452,7 +1475,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "gpu_edge_temperature{gpu_uuid=\"$g_gpu_uuid\", card_model!=\"$g_mi300_model\"}",
+          "expr": "gpu_edge_temperature{gpu_uuid=\"$g_gpu_uuid\", card_model!~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1468,7 +1491,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "gpu_junction_temperature{gpu_uuid=\"$g_gpu_uuid\", card_model=\"$g_mi300_model\"}",
+          "expr": "gpu_junction_temperature{gpu_uuid=\"$g_gpu_uuid\", card_model=~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"}",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1735,8 +1758,8 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(gpu_uuid)",
-        "hide": 0,
+        "definition": "label_values({hostname=\"$g_hostname\", gpu_id=\"$g_gpu_id\"}, gpu_uuid)",
+        "hide": 2,
         "includeAll": false,
         "label": "GPU UUID",
         "multi": false,
@@ -1744,7 +1767,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(gpu_uuid)",
+          "query": "label_values({hostname=\"$g_hostname\", gpu_id=\"$g_gpu_id\"}, gpu_uuid)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -1759,15 +1782,16 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values({gpu_uuid=\"$g_gpu_uuid\"},card_series)",
-        "hide": 2,
+        "definition": "label_values(hostname)",
+        "hide": 0,
         "includeAll": false,
+        "label": "Hostname",
         "multi": false,
-        "name": "g_card_series",
+        "name": "g_hostname",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values({gpu_uuid=\"$g_gpu_uuid\"},card_series)",
+          "query": "label_values(hostname)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -1782,15 +1806,16 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values({gpu_uuid=\"$g_gpu_uuid\"},gpu_id)",
-        "hide": 2,
+        "definition": "label_values({hostname=\"$g_hostname\"},gpu_id)",
+        "hide": 0,
         "includeAll": false,
+        "label": "GPU ID",
         "multi": false,
         "name": "g_gpu_id",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values({gpu_uuid=\"$g_gpu_uuid\"},gpu_id)",
+          "query": "label_values({hostname=\"$g_hostname\"},gpu_id)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -1874,18 +1899,18 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values({gpu_uuid=\"$g_gpu_uuid\"},card_model)",
+        "definition": "label_values({gpu_uuid=\"$g_gpu_uuid\"},card_series)",
         "hide": 2,
         "includeAll": false,
         "multi": false,
-        "name": "g_card_model",
+        "name": "g_card_series",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values({gpu_uuid=\"$g_gpu_uuid\"},card_model)",
+          "query": "label_values({gpu_uuid=\"$g_gpu_uuid\"},card_series)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -1897,15 +1922,15 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values({gpu_uuid=\"$g_gpu_uuid\"},hostname)",
+        "definition": "label_values({gpu_uuid=\"$g_gpu_uuid\"},card_model)",
         "hide": 2,
         "includeAll": false,
         "multi": false,
-        "name": "g_hostname",
+        "name": "g_card_model",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values({gpu_uuid=\"$g_gpu_uuid\"},hostname)",
+          "query": "label_values({gpu_uuid=\"$g_gpu_uuid\"},card_model)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -1931,31 +1956,11 @@
           "query": "label_values({gpu_uuid=\"$g_gpu_uuid\"},serial_number)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
-      },
-      {
-        "hide": 2,
-        "label": "MI300 Model",
-        "name": "g_mi300_model",
-        "query": "${VAR_G_MI300_MODEL}",
-        "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_G_MI300_MODEL}",
-          "text": "${VAR_G_MI300_MODEL}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_G_MI300_MODEL}",
-            "text": "${VAR_G_MI300_MODEL}",
-            "selected": false
-          }
-        ]
       }
     ]
   },

--- a/grafana/dashboard_job.json
+++ b/grafana/dashboard_job.json
@@ -14,13 +14,6 @@
       "description": "",
       "type": "datasource",
       "pluginId": "__expr__"
-    },
-    {
-      "name": "VAR_G_MI300_MODEL",
-      "type": "constant",
-      "label": "MI300 Model",
-      "value": "102-G30211-00",
-      "description": ""
     }
   ],
   "__elements": {},
@@ -34,7 +27,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.2.2+security-01"
+      "version": "11.2.2"
     },
     {
       "type": "datasource",
@@ -111,7 +104,7 @@
         "content": "${g_job_id}\n${g_pod}",
         "mode": "markdown"
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "title": "Name",
       "type": "text"
     },
@@ -169,7 +162,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -308,21 +301,25 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "editorMode": "code",
+          "disableTextWrap": false,
+          "editorMode": "builder",
           "exemplar": false,
-          "expr": "pcie_max_speed{job_id!=\"\", job_id=\"$g_job_id\"}",
+          "expr": "max(pcie_max_speed{job_id!=\"\", job_id=\"$g_job_id\"})",
+          "fullMetaSearch": false,
           "hide": false,
+          "includeNullMetadata": true,
           "instant": false,
           "legendFormat": "{{job_id}}",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "useBackend": false
         },
         {
           "datasource": {
@@ -332,7 +329,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "pcie_max_speed{pod!=\"\", pod=\"$g_pod\"}",
+          "expr": "max(pcie_max_speed{pod!=\"\", pod=\"$g_pod\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -397,7 +394,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -555,7 +552,7 @@
             {
               "targetBlank": true,
               "title": "Go to GPU Dashboard",
-              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__field.labels.gpu_uuid}"
+              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__field.labels.gpu_uuid}&var-g_hostname=${__field.labels.hostname}&var-g_gpu_id=${__field.labels.gpu_id}"
             }
           ],
           "mappings": [],
@@ -602,7 +599,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -659,7 +656,7 @@
             {
               "targetBlank": true,
               "title": "Go to GPU Dashboard",
-              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__field.labels.gpu_uuid}"
+              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__field.labels.gpu_uuid}&var-g_hostname=${__field.labels.hostname}&var-g_gpu_id=${__field.labels.gpu_id}"
             }
           ],
           "mappings": [],
@@ -705,7 +702,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -800,7 +797,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -913,7 +910,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -949,7 +946,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Latest total power usage, in Watts",
+      "description": "Total package power usage, in Watts",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -962,10 +959,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -998,7 +991,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -1007,11 +1000,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(gpu_power_usage{job_id!=\"\", job_id=\"$g_job_id\"})",
+          "expr": "sum(gpu_average_package_power{job_id!=\"\", job_id=\"$g_job_id\"})",
           "fullMetaSearch": false,
+          "hide": true,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Power Usage",
+          "legendFormat": "Average Job Package Power Usage",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1023,15 +1017,69 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(gpu_power_usage{pod!=\"\", pod=\"$g_pod\"})",
+          "expr": "sum(gpu_package_power{job_id!=\"\", job_id=\"$g_job_id\"})",
           "fullMetaSearch": false,
-          "hide": false,
+          "hide": true,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Power Usage",
+          "legendFormat": "Job Package Power Usage",
           "range": true,
           "refId": "B",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(gpu_average_package_power{pod!=\"\", pod=\"$g_pod\"})",
+          "fullMetaSearch": false,
+          "hide": true,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Average Pod Package Power Usage",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(gpu_package_power{pod!=\"\", pod=\"$g_pod\"})",
+          "fullMetaSearch": false,
+          "hide": true,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Pod Package Power Usage",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A+$B",
+          "hide": false,
+          "refId": "Total Job Package Power Usage",
+          "type": "math"
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$C+$D",
+          "hide": false,
+          "refId": "Total Pod Package Power Usage",
+          "type": "math"
         }
       ],
       "title": "Total Power Usage",
@@ -1163,7 +1211,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "\\# of GPUs used by the job",
+      "description": "\\# of GPUs allocated by the job",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1211,10 +1259,13 @@
           "values": false
         },
         "showPercentChange": false,
+        "text": {
+          "titleSize": 9
+        },
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -1228,9 +1279,9 @@
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "# of GPUs used",
-          "range": true,
+          "instant": true,
+          "legendFormat": "Allocated by Jobs",
+          "range": false,
           "refId": "A",
           "useBackend": false
         },
@@ -1246,14 +1297,42 @@
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "# of GPUs used",
-          "range": true,
+          "instant": true,
+          "legendFormat": "Allocated by Pods",
+          "range": false,
           "refId": "B",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(group by(gpu_id) (gpu_gfx_activity{job_id!=\"\", job_id=\"$g_job_id\"} > 0))",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Busy GPUs",
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(group by(gpu_id) (gpu_gfx_activity{pod!=\"\", pod=\"$g_pod\"} > 0))",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Busy GPUs",
+          "range": false,
+          "refId": "D"
         }
       ],
-      "title": "GPUs",
+      "title": "Allocated GPUs",
       "type": "stat"
     },
     {
@@ -1309,62 +1388,78 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "gpu_ecc_correct_total{job_id!=\"\", job_id=\"$g_job_id\"}",
+          "expr": "sum(gpu_ecc_correct_total{job_id!=\"\", job_id=\"$g_job_id\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
           "instant": true,
           "legendFormat": "Correctable",
           "range": false,
-          "refId": "A"
+          "refId": "A",
+          "useBackend": false
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "gpu_ecc_correct_total{pod!=\"\", pod=\"$g_pod\"}",
+          "expr": "sum(gpu_ecc_correct_total{pod!=\"\", pod=\"$g_pod\"})",
+          "fullMetaSearch": false,
           "hide": false,
+          "includeNullMetadata": true,
           "instant": true,
           "legendFormat": "Correctable",
           "range": false,
-          "refId": "B"
+          "refId": "B",
+          "useBackend": false
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "gpu_ecc_uncorrect_total{job_id!=\"\", job_id=\"$g_job_id\"}",
+          "expr": "sum(gpu_ecc_uncorrect_total{job_id!=\"\", job_id=\"$g_job_id\"})",
+          "fullMetaSearch": false,
           "hide": false,
+          "includeNullMetadata": true,
           "instant": true,
           "legendFormat": "Uncorrectable",
           "range": false,
-          "refId": "C"
+          "refId": "C",
+          "useBackend": false
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "gpu_ecc_uncorrect_total{pod!=\"\", pod=\"$g_pod\"}",
+          "expr": "sum(gpu_ecc_uncorrect_total{pod!=\"\", pod=\"$g_pod\"})",
+          "fullMetaSearch": false,
           "hide": false,
+          "includeNullMetadata": true,
           "instant": true,
           "legendFormat": "Uncorrectable",
           "range": false,
-          "refId": "D"
+          "refId": "D",
+          "useBackend": false
         }
       ],
       "title": "Total ECC Counts",
@@ -1758,7 +1853,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg(gpu_package_power{job_id!=\"\", job_id=\"$g_job_id\"})",
+          "expr": "avg(gpu_package_power{job_id!=\"\", job_id=\"$g_job_id\", card_model=~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1774,7 +1869,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg(gpu_package_power{pod!=\"\", pod=\"$g_pod\"})",
+          "expr": "avg(gpu_package_power{pod!=\"\", pod=\"$g_pod\", card_model=~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1783,6 +1878,32 @@
           "range": true,
           "refId": "B",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "avg(gpu_average_package_power{job_id!=\"\", job_id=\"$g_job_id\", card_model!~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "avg(gpu_average_package_power{pod!=\"\", pod=\"$g_pod\", card_model!~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Average GPU Power",
@@ -1878,8 +1999,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "avg(gpu_edge_temperature{job_id!=\"\", job_id=\"$g_job_id\", card_model!=\"$g_mi300_model\"})",
+          "editorMode": "builder",
+          "expr": "avg(gpu_edge_temperature{job_id!=\"\", job_id=\"$g_job_id\", card_model!~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1895,7 +2016,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg(gpu_edge_temperature{pod!=\"\", pod=\"$g_pod\", card_model!=\"$g_mi300_model\"})",
+          "expr": "avg(gpu_edge_temperature{pod!=\"\", pod=\"$g_pod\", card_model!~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1912,7 +2033,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg(gpu_junction_temperature{job_id!=\"\", job_id=\"$g_job_id\", card_model=\"$g_mi300_model\"})",
+          "expr": "avg(gpu_junction_temperature{job_id!=\"\", job_id=\"$g_job_id\", card_model=~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1929,7 +2050,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg(gpu_junction_temperature{pod!=\"\", pod=\"$g_pod\", card_model=\"$g_mi300_model\"})",
+          "expr": "avg(gpu_junction_temperature{pod!=\"\", pod=\"$g_pod\", card_model=~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2274,7 +2395,7 @@
             {
               "targetBlank": true,
               "title": "Go to GPU Dashboard",
-              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__data.fields[\"gpu_uuid\"]}"
+              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__data.fields[\"gpu_uuid\"]}&var-g_hostname=${__data.fields.HOSTNAME}&var-g_gpu_id=${__data.fields[\"GPU ID\"]}"
             }
           ],
           "mappings": [],
@@ -2282,8 +2403,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -2345,7 +2465,7 @@
           }
         ]
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -2438,6 +2558,7 @@
   "templating": {
     "list": [
       {
+        "allValue": "+",
         "current": {},
         "datasource": {
           "type": "prometheus",
@@ -2462,6 +2583,7 @@
         "type": "query"
       },
       {
+        "allValue": "+",
         "current": {},
         "datasource": {
           "type": "prometheus",
@@ -2484,26 +2606,6 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
-      },
-      {
-        "hide": 2,
-        "label": "MI300 Model",
-        "name": "g_mi300_model",
-        "query": "${VAR_G_MI300_MODEL}",
-        "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_G_MI300_MODEL}",
-          "text": "${VAR_G_MI300_MODEL}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_G_MI300_MODEL}",
-            "text": "${VAR_G_MI300_MODEL}",
-            "selected": false
-          }
-        ]
       }
     ]
   },

--- a/grafana/dashboard_node.json
+++ b/grafana/dashboard_node.json
@@ -14,13 +14,6 @@
       "description": "",
       "type": "datasource",
       "pluginId": "__expr__"
-    },
-    {
-      "name": "VAR_G_MI300_MODEL",
-      "type": "constant",
-      "label": "MI300 Model",
-      "value": "102-G30211-00",
-      "description": ""
     }
   ],
   "__elements": {},
@@ -34,7 +27,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.2.2+security-01"
+      "version": "11.2.2"
     },
     {
       "type": "datasource",
@@ -139,7 +132,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -218,7 +211,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -260,7 +253,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "\\# of GPUs being used by jobs",
+      "description": "\\# of GPUs allocated by jobs",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -298,7 +291,7 @@
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
@@ -308,10 +301,13 @@
           "values": false
         },
         "showPercentChange": false,
+        "text": {
+          "titleSize": 13
+        },
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -323,9 +319,10 @@
           "exemplar": false,
           "expr": "sum(group by(gpu_id) (gpu_gfx_activity{hostname=\"$g_hostname\", job_id!=\"\"}))",
           "fullMetaSearch": false,
+          "hide": false,
           "includeNullMetadata": true,
           "instant": true,
-          "legendFormat": "Used GPUs (jobs)",
+          "legendFormat": "Allocated by Jobs",
           "range": false,
           "refId": "A",
           "useBackend": false
@@ -343,7 +340,7 @@
           "hide": false,
           "includeNullMetadata": true,
           "instant": true,
-          "legendFormat": "Used GPUs (pods)",
+          "legendFormat": "Allocated by Pods",
           "range": false,
           "refId": "B",
           "useBackend": false
@@ -354,20 +351,20 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(group by(gpu_id) (gpu_gfx_activity{hostname=\"$g_hostname\"}))",
+          "expr": "sum(group by(gpu_id) (gpu_gfx_activity{hostname=\"$g_hostname\"} > 0))",
           "fullMetaSearch": false,
-          "hide": true,
+          "hide": false,
           "includeNullMetadata": true,
           "instant": true,
-          "legendFormat": "Available GPUs",
+          "legendFormat": "Busy GPUs",
           "range": false,
           "refId": "C",
           "useBackend": false
         }
       ],
-      "title": "Used GPUs",
+      "title": "Allocated GPUs",
       "type": "stat"
     },
     {
@@ -425,7 +422,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -510,7 +507,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -665,7 +662,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -703,7 +700,7 @@
             {
               "targetBlank": true,
               "title": "Go to GPU Dashboard",
-              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__field.labels.gpu_uuid}"
+              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__field.labels.gpu_uuid}&var-g_hostname=${__field.labels.hostname}&var-g_gpu_id=${__field.labels.gpu_id}"
             }
           ],
           "mappings": [],
@@ -749,7 +746,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -777,7 +774,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Total power usage, in Watts",
+      "description": "Total package power usage, in Watts",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -790,10 +787,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -826,7 +819,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -835,13 +828,41 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(gpu_power_usage{hostname=\"$g_hostname\"})",
+          "expr": "sum(gpu_average_package_power{hostname=\"$g_hostname\"})",
           "fullMetaSearch": false,
+          "hide": true,
           "includeNullMetadata": true,
-          "legendFormat": "Power Usage (W)",
+          "legendFormat": "Average Package Power Usage",
           "range": true,
           "refId": "A",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(gpu_package_power{hostname=\"$g_hostname\"})",
+          "fullMetaSearch": false,
+          "hide": true,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Package Power Usage",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A+$B",
+          "hide": false,
+          "refId": "Total Package Power Usage",
+          "type": "math"
         }
       ],
       "title": "Total Power Usage",
@@ -896,7 +917,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -970,7 +991,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -1174,7 +1195,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -1265,7 +1286,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -1625,13 +1646,26 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg(gpu_package_power{hostname=\"$g_hostname\"})",
+          "expr": "avg(gpu_package_power{hostname=\"$g_hostname\", card_model=~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "avg(gpu_average_package_power{hostname=\"$g_hostname\", card_model!~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Average GPU Power",
@@ -1754,8 +1788,9 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg(gpu_edge_temperature{hostname=\"$g_hostname\", card_model!=\"$g_mi300_model\"})",
+          "expr": "avg(gpu_edge_temperature{hostname=\"$g_hostname\", card_model!~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
+          "hide": false,
           "includeNullMetadata": true,
           "legendFormat": "Edge Temperature",
           "range": true,
@@ -1769,7 +1804,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "gpu_junction_temperature{hostname=\"$g_hostname\", card_model=\"$g_mi300_model\"}",
+          "expr": "avg(gpu_junction_temperature{hostname=\"$g_hostname\", card_model=~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2047,7 +2082,7 @@
             {
               "targetBlank": true,
               "title": "Go to GPU Dashboard",
-              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__data.fields[\"gpu_uuid\"]}"
+              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__data.fields[\"gpu_uuid\"]}&var-g_hostname=${__data.fields.HOSTNAME}&var-g_gpu_id=${__data.fields[\"GPU ID\"]}"
             }
           ],
           "mappings": [],
@@ -2055,8 +2090,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -2118,7 +2152,7 @@
           }
         ]
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -2224,26 +2258,6 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
-      },
-      {
-        "hide": 2,
-        "label": "MI300 Model",
-        "name": "g_mi300_model",
-        "query": "${VAR_G_MI300_MODEL}",
-        "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_G_MI300_MODEL}",
-          "text": "${VAR_G_MI300_MODEL}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_G_MI300_MODEL}",
-            "text": "${VAR_G_MI300_MODEL}",
-            "selected": false
-          }
-        ]
       }
     ]
   },

--- a/grafana/dashboard_overview.json
+++ b/grafana/dashboard_overview.json
@@ -14,13 +14,6 @@
       "description": "",
       "type": "datasource",
       "pluginId": "__expr__"
-    },
-    {
-      "name": "VAR_G_MI300_MODEL",
-      "type": "constant",
-      "label": "MI300 Model",
-      "value": "102-G30211-00",
-      "description": ""
     }
   ],
   "__elements": {},
@@ -34,7 +27,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.2.2+security-01"
+      "version": "11.2.2"
     },
     {
       "type": "datasource",
@@ -117,7 +110,7 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 3,
+        "w": 2,
         "x": 0,
         "y": 0
       },
@@ -139,7 +132,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -167,6 +160,99 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Number of jobs",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Go to Job Dashboard",
+              "url": "/d/ce1x81pyv3dvkb/job"
+            }
+          ],
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 2,
+        "y": 0
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum(group by(job_id) (gpu_gfx_activity{job_id!=\"\"}))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Jobs",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum(group by(pod) (gpu_gfx_activity{pod!=\"\"}))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Pods",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Jobs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Total power usage, in Watts",
       "fieldConfig": {
         "defaults": {
@@ -180,10 +266,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -193,8 +275,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 5,
-        "x": 3,
+        "w": 4,
+        "x": 4,
         "y": 0
       },
       "id": 2,
@@ -216,7 +298,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -225,14 +307,42 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(gpu_power_usage)",
+          "expr": "sum(gpu_average_package_power)",
           "fullMetaSearch": false,
+          "hide": true,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "Power Usage (W)",
+          "legendFormat": "Average Package Power (W)",
           "range": true,
           "refId": "A",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(gpu_package_power)",
+          "fullMetaSearch": false,
+          "hide": true,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Current Package Power (W)",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "${DS_EXPRESSION}"
+          },
+          "expression": "$A+$B",
+          "hide": false,
+          "refId": "Total Package Power Usage",
+          "type": "math"
         }
       ],
       "title": "Total Power Usage",
@@ -287,7 +397,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -375,7 +485,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -480,7 +590,7 @@
             {
               "targetBlank": true,
               "title": "Go to GPU dashboard",
-              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__field.labels.gpu_uuid}"
+              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__field.labels.gpu_uuid}&var-g_hostname=${__field.labels.hostname}&var-g_gpu_id=${__field.labels.gpu_id}"
             }
           ],
           "mappings": [],
@@ -526,7 +636,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -603,7 +713,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -676,7 +786,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -729,8 +839,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 5,
-        "x": 3,
+        "w": 4,
+        "x": 4,
         "y": 4
       },
       "id": 24,
@@ -751,7 +861,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -805,7 +915,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Number of jobs",
+      "description": "\\# of GPUs allocated by jobs",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -814,8 +924,8 @@
           "links": [
             {
               "targetBlank": true,
-              "title": "Go to Job Dashboard",
-              "url": "/d/ce1x81pyv3dvkb/job"
+              "title": "Go to GPU Dashboard",
+              "url": "/d/ae0aj8euc43r4b/gpu"
             }
           ],
           "mappings": [],
@@ -834,16 +944,16 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 3,
+        "w": 4,
         "x": 0,
         "y": 6
       },
-      "id": 22,
+      "id": 34,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
@@ -853,27 +963,26 @@
           "values": false
         },
         "showPercentChange": false,
+        "text": {
+          "titleSize": 13
+        },
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "sum(group by(job_id) (gpu_gfx_activity{job_id!=\"\"}))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "Jobs",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
+          "expr": "sum(group by(gpu_uuid) (gpu_gfx_activity{job_id!=\"\"}))",
+          "instant": true,
+          "legendFormat": "Allocated by Jobs",
+          "range": false,
+          "refId": "A"
         },
         {
           "datasource": {
@@ -882,15 +991,29 @@
           },
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "sum(group by(pod) (gpu_gfx_activity{pod!=\"\"}))",
+          "expr": "sum(group by(gpu_uuid) (gpu_gfx_activity{pod!=\"\"}))",
           "hide": false,
-          "instant": false,
-          "legendFormat": "Pods",
-          "range": true,
+          "instant": true,
+          "legendFormat": "Allocated by Pods",
+          "range": false,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(group by(gpu_uuid) (gpu_gfx_activity > 0))",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "Busy GPUs",
+          "range": false,
+          "refId": "C"
         }
       ],
-      "title": "Jobs",
+      "title": "Allocated GPUs",
       "type": "stat"
     },
     {
@@ -1027,8 +1150,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 5,
-        "x": 3,
+        "w": 4,
+        "x": 4,
         "y": 8
       },
       "id": 8,
@@ -1050,7 +1173,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -1408,7 +1531,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg(gpu_package_power)",
+          "expr": "avg(gpu_package_power{card_model=~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1416,6 +1539,19 @@
           "range": true,
           "refId": "A",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "avg(gpu_average_package_power{card_model!~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "GPU Power",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Average GPU Power",
@@ -1512,7 +1648,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg(gpu_edge_temperature{card_model!=\"$g_mi300_model\"})",
+          "expr": "avg(gpu_edge_temperature{card_model!~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1529,7 +1665,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg(gpu_junction_temperature{card_model=\"$g_mi300_model\"})",
+          "expr": "avg(gpu_junction_temperature{card_model=~\"102-G30211-00|102-G30211-0C|102-G30211-4C|102-G30212-0C|102-G30213-00|102-G30213-0C\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1812,7 +1948,7 @@
             {
               "targetBlank": true,
               "title": "Go to GPU Dashboard",
-              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__data.fields[\"gpu_uuid\"]}"
+              "url": "/d/ae0aj8euc43r4b/gpu?var-g_gpu_uuid=${__data.fields[\"gpu_uuid\"]}&var-g_hostname=${__data.fields.HOSTNAME}&var-g_gpu_id=${__data.fields[\"GPU ID\"]}"
             }
           ],
           "mappings": [],
@@ -1820,8 +1956,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -1883,7 +2018,7 @@
           }
         ]
       },
-      "pluginVersion": "11.2.2+security-01",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -2030,26 +2165,6 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
-      },
-      {
-        "hide": 2,
-        "label": "MI300 Model",
-        "name": "g_mi300_model",
-        "query": "${VAR_G_MI300_MODEL}",
-        "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_G_MI300_MODEL}",
-          "text": "${VAR_G_MI300_MODEL}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_G_MI300_MODEL}",
-            "text": "${VAR_G_MI300_MODEL}",
-            "selected": false
-          }
-        ]
       }
     ]
   },


### PR DESCRIPTION
update to latest grafana dashboard configs and sync with device-metrics-exporter

latest PR description:

in power usage tile, on all dashboards, switch from using gpu_power_usage metric to gpu_average_package_power and gpu_package_power

device-metrics-exporter PR: https://github.com/ROCm/device-metrics-exporter/pull/24
pensando repo PR: https://github.com/pensando/device-metrics-exporter/pull/205