### PR TITLE
Adding SecurityContextConstraint access to test runner role

### DIFF
--- a/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -30,8 +30,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-13T11:48:39Z"
-    operatorframework.io/suggested-namespace: kube-amd-gpu
+    createdAt: "2025-03-18T22:58:17Z"
+    operatorframework.io/suggested-namespace: openshift-amd-gpu
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/ROCm/gpu-operator
@@ -946,6 +946,14 @@ spec:
           - nodes
           verbs:
           - patch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
         serviceAccountName: amd-gpu-operator-test-runner
       deployments:
       - label:

--- a/config/manifests/bases/amd-gpu-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/amd-gpu-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    operatorframework.io/suggested-namespace: kube-amd-gpu
+    operatorframework.io/suggested-namespace: openshift-amd-gpu
     repository: https://github.com/ROCm/gpu-operator
   name: amd-gpu-operator.v0.0.0
   namespace: placeholder

--- a/config/rbac/test_runner_role.yaml
+++ b/config/rbac/test_runner_role.yaml
@@ -9,3 +9,11 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["patch"]
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/hack/openshift-patch/template-patch/test-runner-rbac.yaml
+++ b/hack/openshift-patch/template-patch/test-runner-rbac.yaml
@@ -23,6 +23,14 @@ rules:
   - nodes
   verbs:
   - patch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm-charts-openshift/Chart.lock
+++ b/helm-charts-openshift/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:25200c34a5cc846a1275e5bf3fc637b19e909dc68de938189c5278d77d03f5ac
-generated: "2025-03-13T11:52:41.415392055Z"
+generated: "2025-03-18T22:58:15.38295759Z"

--- a/helm-charts-openshift/templates/test-runner-rbac.yaml
+++ b/helm-charts-openshift/templates/test-runner-rbac.yaml
@@ -23,6 +23,14 @@ rules:
   - nodes
   verbs:
   - patch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Adding SecurityContextConstraint access to test runner role so that OpenShift cluster could allow test runner pod to run privileged containers.