### PR TITLE
Fix the wrong assignment of docker-save file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ IMAGE_NAME ?= gpu-operator
 IMAGE_TAG_BASE ?= $(DOCKER_REGISTRY)/$(IMAGE_NAME)
 IMAGE_TAG ?= dev
 IMG ?= $(IMAGE_TAG_BASE):$(IMAGE_TAG)
-DOCKER_CONTAINER_IMG = $(IMAGE_NAME)-$(IMAGE_TAG) # name used for saving the container images as tar.gz
+# name used for saving the container images as tar.gz
+DOCKER_CONTAINER_IMG = $(IMAGE_NAME)-$(IMAGE_TAG)
 HOURLY_TAG_LABEL ?= latest
 
 # KMM related images


### PR DESCRIPTION
the current comment in ```Makefile``` will lead to wrong value assignment to the ENV ```DOCKER_CONTAINER_IMG```, there will be one more extra whitespace assigned to that ENV.

Move the comment to a different line can resolve the issue.