### PR TITLE
Utils Container Openshift Security Context Constraint access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,7 +353,7 @@ bundle-build: operator-sdk manifests kustomize ## OpenShift Build OLM bundle.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd config/manager-base && $(KUSTOMIZE) edit set image controller=$(IMG)
 	OPERATOR_SDK="${OPERATOR_SDK}" \
-		     BUNDLE_GEN_FLAGS="${BUNDLE_GEN_FLAGS} --extra-service-accounts amd-gpu-operator-kmm-device-plugin,amd-gpu-operator-kmm-module-loader,amd-gpu-operator-node-labeller,amd-gpu-operator-metrics-exporter,amd-gpu-operator-metrics-exporter-rbac-proxy,amd-gpu-operator-test-runner,amd-gpu-operator-config-manager" \
+		     BUNDLE_GEN_FLAGS="${BUNDLE_GEN_FLAGS} --extra-service-accounts amd-gpu-operator-kmm-device-plugin,amd-gpu-operator-kmm-module-loader,amd-gpu-operator-node-labeller,amd-gpu-operator-metrics-exporter,amd-gpu-operator-metrics-exporter-rbac-proxy,amd-gpu-operator-test-runner,amd-gpu-operator-config-manager,amd-gpu-operator-utils-container" \
 		     PKG=amd-gpu-operator \
 		     SOURCE_DIR=$(dir $(realpath $(lastword $(MAKEFILE_LIST)))) \
 		     KUBECTL_CMD=${KUBECTL_CMD} ./hack/generate-bundle

--- a/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-18T22:58:17Z"
+    createdAt: "2025-03-20T06:06:57Z"
     operatorframework.io/suggested-namespace: openshift-amd-gpu
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -955,6 +955,16 @@ spec:
           verbs:
           - use
         serviceAccountName: amd-gpu-operator-test-runner
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: amd-gpu-operator-utils-container
       deployments:
       - label:
           app.kubernetes.io/component: amd-gpu

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -22,3 +22,6 @@ resources:
   - test_runner_service_account.yaml
   - test_runner_role.yaml
   - test_runner_role_binding.yaml
+  - utils_container_service_account.yaml
+  - utils_container_role.yaml
+  - utils_container_role_binding.yaml

--- a/config/rbac/utils_container_role.yaml
+++ b/config/rbac/utils_container_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: utils-container
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/config/rbac/utils_container_role_binding.yaml
+++ b/config/rbac/utils_container_role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: utils-container
+subjects:
+- kind: ServiceAccount
+  name: utils-container
+roleRef:
+  kind: ClusterRole
+  name: utils-container
+  apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/utils_container_service_account.yaml
+++ b/config/rbac/utils_container_service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: utils-container

--- a/hack/k8s-patch/metadata-patch/values.yaml
+++ b/hack/k8s-patch/metadata-patch/values.yaml
@@ -101,6 +101,9 @@ testRunner:
 configManager:
   serviceAccount:
     annotations: {}
+utilsContainer:
+  serviceAccount:
+    annotations: {}
 global:
   proxy:
     env: {}

--- a/hack/k8s-patch/template-patch/serviceaccount.yaml
+++ b/hack/k8s-patch/template-patch/serviceaccount.yaml
@@ -85,3 +85,14 @@ metadata:
   {{- include "helm-charts-k8s.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.configManager.serviceAccount.annotations | nindent 4 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: amd-gpu-operator-utils-container
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-k8s.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.utilsContainer.serviceAccount.annotations | nindent 4 }}

--- a/hack/k8s-patch/template-patch/utils-container-rbac.yaml
+++ b/hack/k8s-patch/template-patch/utils-container-rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "helm-charts-k8s.fullname" . }}-utils-container
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-k8s.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "helm-charts-k8s.fullname" . }}-utils-container
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-k8s.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "helm-charts-k8s.fullname" . }}-utils-container'
+subjects:
+- kind: ServiceAccount
+  name: amd-gpu-operator-utils-container
+  namespace: '{{ .Release.Namespace }}'

--- a/hack/openshift-patch/template-patch/utils-container-rbac.yaml
+++ b/hack/openshift-patch/template-patch/utils-container-rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "helm-charts-openshift.fullname" . }}-utils-container
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-openshift.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "helm-charts-openshift.fullname" . }}-utils-container
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-openshift.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "helm-charts-openshift.fullname" . }}-utils-container'
+subjects:
+- kind: ServiceAccount
+  name: amd-gpu-operator-utils-container
+  namespace: '{{ .Release.Namespace }}'

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:f9a315dd2ce3d515ebf28c8e9a6a82158b493ca2686439ec381487761261b597
-generated: "2025-03-14T23:56:25.183742256Z"
+generated: "2025-03-20T06:06:33.9562362Z"

--- a/helm-charts-k8s/templates/serviceaccount.yaml
+++ b/helm-charts-k8s/templates/serviceaccount.yaml
@@ -85,3 +85,14 @@ metadata:
   {{- include "helm-charts-k8s.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.configManager.serviceAccount.annotations | nindent 4 }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: amd-gpu-operator-utils-container
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-k8s.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.utilsContainer.serviceAccount.annotations | nindent 4 }}

--- a/helm-charts-k8s/templates/utils-container-rbac.yaml
+++ b/helm-charts-k8s/templates/utils-container-rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "helm-charts-k8s.fullname" . }}-utils-container
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-k8s.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "helm-charts-k8s.fullname" . }}-utils-container
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-k8s.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "helm-charts-k8s.fullname" . }}-utils-container'
+subjects:
+- kind: ServiceAccount
+  name: amd-gpu-operator-utils-container
+  namespace: '{{ .Release.Namespace }}'

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -101,6 +101,9 @@ testRunner:
 configManager:
   serviceAccount:
     annotations: {}
+utilsContainer:
+  serviceAccount:
+    annotations: {}
 global:
   proxy:
     env: {}

--- a/helm-charts-openshift/Chart.lock
+++ b/helm-charts-openshift/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:25200c34a5cc846a1275e5bf3fc637b19e909dc68de938189c5278d77d03f5ac
-generated: "2025-03-18T22:58:15.38295759Z"
+generated: "2025-03-20T06:06:55.80187139Z"

--- a/helm-charts-openshift/templates/utils-container-rbac.yaml
+++ b/helm-charts-openshift/templates/utils-container-rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "helm-charts-openshift.fullname" . }}-utils-container
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-openshift.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "helm-charts-openshift.fullname" . }}-utils-container
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-openshift.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "helm-charts-openshift.fullname" . }}-utils-container'
+subjects:
+- kind: ServiceAccount
+  name: amd-gpu-operator-utils-container
+  namespace: '{{ .Release.Namespace }}'

--- a/internal/controllers/upgrademgr.go
+++ b/internal/controllers/upgrademgr.go
@@ -61,6 +61,7 @@ import (
 
 const (
 	defaultUtilsImage = "docker.io/rocm/gpu-operator-utils:latest"
+	defaultSAName     = "amd-gpu-operator-utils-container"
 )
 
 type upgradeMgr struct {
@@ -976,6 +977,7 @@ func (h *upgradeMgrHelper) getRebootPod(nodeName string, dc *amdv1alpha1.DeviceC
 	nodeSelector := map[string]string{}
 	nodeSelector["kubernetes.io/hostname"] = nodeName
 	utilsImage := defaultUtilsImage
+	serviceaccount := defaultSAName
 	if dc.Spec.CommonConfig.UtilsContainer.Image != "" {
 		utilsImage = dc.Spec.CommonConfig.UtilsContainer.Image
 	}
@@ -989,11 +991,12 @@ func (h *upgradeMgrHelper) getRebootPod(nodeName string, dc *amdv1alpha1.DeviceC
 			Namespace: dc.Namespace,
 		},
 		Spec: v1.PodSpec{
-			HostPID:          true,
-			HostNetwork:      true,
-			RestartPolicy:    v1.RestartPolicyNever,
-			NodeSelector:     nodeSelector,
-			ImagePullSecrets: imagePullSecrets,
+			ServiceAccountName: serviceaccount,
+			HostPID:            true,
+			HostNetwork:        true,
+			RestartPolicy:      v1.RestartPolicyNever,
+			NodeSelector:       nodeSelector,
+			ImagePullSecrets:   imagePullSecrets,
 			Containers: []v1.Container{
 				{
 					Name:            "reboot-container",


### PR DESCRIPTION
Reboot Pod requires extra config change using Service account for Privileged access in Openshift.
Same fix which was done for testrunner: https://github.com/pensando/gpu-operator/pull/484

Tested RebootRequired functionality with the fix:

CR updated from 6.3.1 to 6.3.2 (Had already built 6.3.2 and kept it for kmm to unload/load)
Reboot is triggered from CR

```
[core@52-54-00-8b-35-21 ~]$ kubectl get pods -A | grep reboot
kube-amd-gpu                                       amd-gpu-operator-b0-26-28-e8-50-46-reboot-worker                  0/1     Completed     0               49s
kube-amd-gpu                                       amd-gpu-operator-b0-26-28-e8-a4-6a-reboot-worker                  1/1     Running       0               49s
```

Node moves to NotReady state once rebooted

```
[core@52-54-00-8b-35-21 ~]$ kubectl get nodes
NAME                STATUS     ROLES                  AGE   VERSION
52-54-00-13-03-4c   Ready      control-plane,master   26d   v1.31.5
52-54-00-18-ac-97   Ready      control-plane,master   26d   v1.31.5
52-54-00-8b-35-21   Ready      control-plane,master   26d   v1.31.5
b0-26-28-e8-50-46   NotReady   worker                 26d   v1.31.5
b0-26-28-e8-a4-6a   NotReady   worker                 26d   v1.31.5
```

NodeModuleStatus shows Upgrade Status as Reboot-In-Progress

```
nodeModuleStatus:
    b0-26-28-e8-50-46:
      status: Reboot-In-Progress
      upgradeStartTime: 2025-03-18 12:09:36 UTC
    b0-26-28-e8-a4-6a:
      status: Reboot-In-Progress
      upgradeStartTime: 2025-03-18 12:09:36 UTC
```

After sometime, node goes to Ready state after reboot, new version is loaded and Upgrade moves to Upgrade-Complete state

```
[core@52-54-00-8b-35-21 ~]$ kubectl get nodes
NAME                STATUS   ROLES                  AGE   VERSION
52-54-00-13-03-4c   Ready    control-plane,master   26d   v1.31.5
52-54-00-18-ac-97   Ready    control-plane,master   26d   v1.31.5
52-54-00-8b-35-21   Ready    control-plane,master   26d   v1.31.5
b0-26-28-e8-50-46   Ready    worker                 26d   v1.31.5
b0-26-28-e8-a4-6a   Ready    worker                 26d   v1.31.5

nodeModuleStatus:
    b0-26-28-e8-50-46:
      containerImage: registry.test.pensando.io:5000/sriram:coreos-418.94-5.14.0-427.50.2.el9_4.x86_64-6.3.2
      kernelVersion: 5.14.0-427.50.2.el9_4.x86_64
      lastTransitionTime: 2025-03-18 12:16:38 +0000 UTC
      status: Upgrade-Complete
      upgradeStartTime: 2025-03-18 12:09:36 UTC
    b0-26-28-e8-a4-6a:
      containerImage: registry.test.pensando.io:5000/sriram:coreos-418.94-5.14.0-427.50.2.el9_4.x86_64-6.3.2
      kernelVersion: 5.14.0-427.50.2.el9_4.x86_64
      lastTransitionTime: 2025-03-18 12:16:24 +0000 UTC
      status: Upgrade-Complete
      upgradeStartTime: 2025-03-18 12:09:36 UTC
```
      
Device Plugin pods come back up after Driver Upgrade is complete since it was part of the CR
```
[core@52-54-00-8b-35-21 ~]$ kubectl get pods -A | grep amd
kube-amd-gpu                                       amd-gpu-operator-controller-manager-6dd6f875d4-f8qgg              1/1     Running     0                12m
kube-amd-gpu                                       test-deviceconfig-device-plugin-9jvlq                             1/1     Running     0                3m19s
kube-amd-gpu                                       test-deviceconfig-device-plugin-l9zjh                             1/1     Running     0                3m21s 
```