### PR TITLE
Refactor IsOpenShift function based on RedHat suggestion

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,9 +35,6 @@ package main
 import (
 	"flag"
 
-	"github.com/ROCm/gpu-operator/internal/configmanager"
-	"github.com/ROCm/gpu-operator/internal/metricsexporter"
-	"github.com/ROCm/gpu-operator/internal/testrunner"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -51,11 +48,15 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	gpuev1alpha1 "github.com/ROCm/gpu-operator/api/v1alpha1"
+	utils "github.com/ROCm/gpu-operator/internal"
 	"github.com/ROCm/gpu-operator/internal/cmd"
 	"github.com/ROCm/gpu-operator/internal/config"
+	"github.com/ROCm/gpu-operator/internal/configmanager"
 	"github.com/ROCm/gpu-operator/internal/controllers"
 	"github.com/ROCm/gpu-operator/internal/kmmmodule"
+	"github.com/ROCm/gpu-operator/internal/metricsexporter"
 	"github.com/ROCm/gpu-operator/internal/nodelabeller"
+	"github.com/ROCm/gpu-operator/internal/testrunner"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -107,8 +108,9 @@ func main() {
 	}
 
 	client := mgr.GetClient()
-	kmmHandler := kmmmodule.NewKMMModule(client, scheme)
-	nlHandler := nodelabeller.NewNodeLabeller(scheme)
+	isOpenShift := utils.IsOpenShift(setupLogger)
+	kmmHandler := kmmmodule.NewKMMModule(client, scheme, isOpenShift)
+	nlHandler := nodelabeller.NewNodeLabeller(scheme, isOpenShift)
 	metricsHandler := metricsexporter.NewMetricsExporter(scheme)
 	testrunnerHandler := testrunner.NewTestRunner(scheme)
 	configmanagerHandler := configmanager.NewConfigManager(scheme)

--- a/internal/kmmmodule/kmmmodule.go
+++ b/internal/kmmmodule/kmmmodule.go
@@ -55,10 +55,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -107,25 +105,12 @@ type kmmModule struct {
 	isOpenShift bool
 }
 
-func NewKMMModule(client client.Client, scheme *runtime.Scheme) KMMModuleAPI {
+func NewKMMModule(client client.Client, scheme *runtime.Scheme, isOpenShift bool) KMMModuleAPI {
 	return &kmmModule{
 		client:      client,
 		scheme:      scheme,
-		isOpenShift: isOpenshift(),
+		isOpenShift: isOpenShift,
 	}
-}
-
-func isOpenshift() bool {
-	if dc, err := discovery.NewDiscoveryClientForConfig(ctrl.GetConfigOrDie()); err == nil {
-		if gplist, err := dc.ServerGroups(); err == nil {
-			for _, gp := range gplist.Groups {
-				if gp.Name == "route.openshift.io" {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 func (km *kmmModule) SetNodeVersionLabelAsDesired(ctx context.Context, devConfig *amdv1alpha1.DeviceConfig, nodes *v1.NodeList) error {

--- a/internal/nodelabeller/nodelabeller.go
+++ b/internal/nodelabeller/nodelabeller.go
@@ -42,9 +42,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/discovery"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -66,24 +64,11 @@ type nodeLabeller struct {
 	isOpenShift bool
 }
 
-func NewNodeLabeller(scheme *runtime.Scheme) NodeLabeller {
+func NewNodeLabeller(scheme *runtime.Scheme, isOpenshift bool) NodeLabeller {
 	return &nodeLabeller{
 		scheme:      scheme,
-		isOpenShift: isOpenshift(),
+		isOpenShift: isOpenshift,
 	}
-}
-
-func isOpenshift() bool {
-	if dc, err := discovery.NewDiscoveryClientForConfig(ctrl.GetConfigOrDie()); err == nil {
-		if gplist, err := dc.ServerGroups(); err == nil {
-			for _, gp := range gplist.Groups {
-				if gp.Name == "route.openshift.io" {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 func (nl *nodeLabeller) SetNodeLabellerAsDesired(ds *appsv1.DaemonSet, devConfig *amdv1alpha1.DeviceConfig) error {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -17,15 +17,23 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	amdv1alpha1 "github.com/ROCm/gpu-operator/api/v1alpha1"
+	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	amdv1alpha1 "github.com/ROCm/gpu-operator/api/v1alpha1"
+	"github.com/ROCm/gpu-operator/internal/cmd"
 )
 
 const (
 	defaultOcDriversVersion = "6.2.2"
+	openShiftNodeLabel      = "node.openshift.io/os_id"
 	NodeFeatureLabelAmdGpu  = "feature.node.kubernetes.io/amd-gpu"
 	NodeFeatureLabelAmdVGpu = "feature.node.kubernetes.io/amd-vgpu"
 )
@@ -87,4 +95,31 @@ func HasNodeLabelKey(node v1.Node, labelKey string) bool {
 		}
 	}
 	return false
+}
+
+func IsOpenShift(logger logr.Logger) bool {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		cmd.FatalError(logger, err, "unable to get cluster config")
+	}
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		cmd.FatalError(logger, err, "unable to create cluster clientset")
+	}
+	// Check for OpenShift-specific labels on nodes
+	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		cmd.FatalError(logger, err, "unable to list nodes")
+	}
+
+	isOpenShift := false
+	for _, node := range nodes.Items {
+		if _, exists := node.Labels[openShiftNodeLabel]; exists {
+			isOpenShift = true
+			break
+		}
+	}
+	logger.Info(fmt.Sprintf("IsOpenShift: %+v", isOpenShift))
+	return isOpenShift
 }


### PR DESCRIPTION
Previously we are checking whether the cluster is OpenShift or vanilla by searching for resource ```route.openshift.io``` and RedHat team reported that this may not work consistently for OpenShift cluster, especially single node cluster, they suggest to look for node label ```node.openshift.io/os_id``` to judge if the cluster is OpenShift or not.

Verified that in OpenShift cluster it is showing ```IsOpenShift: true``` and in non-OpenShift cluster it is showing ```IsOpenShift: false```.