### PR TITLE
Optimize the docs and filename for blacklist function

### DIFF
--- a/api/v1alpha1/deviceconfig_types.go
+++ b/api/v1alpha1/deviceconfig_types.go
@@ -94,7 +94,9 @@ type DriverSpec struct {
 	// +kubebuilder:default=true
 	Enable *bool `json:"enable,omitempty"`
 
-	// blacklist amdgpu drivers on the host
+	// blacklist amdgpu drivers on the host. Node reboot is required to apply the baclklist on the worker nodes.
+	// Not working for OpenShift cluster. OpenShift users please use the Machine Config Operator (MCO) resource to configure amdgpu blacklist.
+	// Example MCO resource is available at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="BlacklistDrivers",xDescriptors={"urn:alm:descriptor:com.amd.deviceconfigs:blacklistDrivers"}
 	Blacklist *bool `json:"blacklist,omitempty"`
 

--- a/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -30,7 +30,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-25T06:19:27Z"
+    createdAt: "2025-03-26T20:10:59Z"
     operatorframework.io/suggested-namespace: openshift-amd-gpu
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -229,7 +229,10 @@ spec:
         path: driver.amdgpuInstallerRepoURL
         x-descriptors:
         - urn:alm:descriptor:com.amd.deviceconfigs:amdgpuInstallerRepoURL
-      - description: blacklist amdgpu drivers on the host
+      - description: blacklist amdgpu drivers on the host. Node reboot is required
+          to apply the baclklist on the worker nodes. Not working for OpenShift cluster.
+          OpenShift users please use the Machine Config Operator (MCO) resource to
+          configure amdgpu blacklist. Example MCO resource is available at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
         displayName: BlacklistDrivers
         path: driver.blacklist
         x-descriptors:

--- a/bundle/manifests/amd.com_deviceconfigs.yaml
+++ b/bundle/manifests/amd.com_deviceconfigs.yaml
@@ -342,7 +342,10 @@ spec:
                       installer URL is https://repo.radeon.com/amdgpu-install by default
                     type: string
                   blacklist:
-                    description: blacklist amdgpu drivers on the host
+                    description: |-
+                      blacklist amdgpu drivers on the host. Node reboot is required to apply the baclklist on the worker nodes.
+                      Not working for OpenShift cluster. OpenShift users please use the Machine Config Operator (MCO) resource to configure amdgpu blacklist.
+                      Example MCO resource is available at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
                     type: boolean
                   enable:
                     default: true

--- a/config/crd/bases/amd.com_deviceconfigs.yaml
+++ b/config/crd/bases/amd.com_deviceconfigs.yaml
@@ -338,7 +338,10 @@ spec:
                       installer URL is https://repo.radeon.com/amdgpu-install by default
                     type: string
                   blacklist:
-                    description: blacklist amdgpu drivers on the host
+                    description: |-
+                      blacklist amdgpu drivers on the host. Node reboot is required to apply the baclklist on the worker nodes.
+                      Not working for OpenShift cluster. OpenShift users please use the Machine Config Operator (MCO) resource to configure amdgpu blacklist.
+                      Example MCO resource is available at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
                     type: boolean
                   enable:
                     default: true

--- a/config/manifests/bases/amd-gpu-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/amd-gpu-operator.clusterserviceversion.yaml
@@ -200,7 +200,10 @@ spec:
         path: driver.amdgpuInstallerRepoURL
         x-descriptors:
         - urn:alm:descriptor:com.amd.deviceconfigs:amdgpuInstallerRepoURL
-      - description: blacklist amdgpu drivers on the host
+      - description: blacklist amdgpu drivers on the host. Node reboot is required
+          to apply the baclklist on the worker nodes. Not working for OpenShift cluster.
+          OpenShift users please use the Machine Config Operator (MCO) resource to
+          configure amdgpu blacklist. Example MCO resource is available at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
         displayName: BlacklistDrivers
         path: driver.blacklist
         x-descriptors:

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:f9a315dd2ce3d515ebf28c8e9a6a82158b493ca2686439ec381487761261b597
-generated: "2025-03-25T06:19:17.248998622Z"
+generated: "2025-03-26T20:10:45.247725094Z"

--- a/helm-charts-k8s/crds/deviceconfig-crd.yaml
+++ b/helm-charts-k8s/crds/deviceconfig-crd.yaml
@@ -346,7 +346,10 @@ spec:
                       installer URL is https://repo.radeon.com/amdgpu-install by default
                     type: string
                   blacklist:
-                    description: blacklist amdgpu drivers on the host
+                    description: |-
+                      blacklist amdgpu drivers on the host. Node reboot is required to apply the baclklist on the worker nodes.
+                      Not working for OpenShift cluster. OpenShift users please use the Machine Config Operator (MCO) resource to configure amdgpu blacklist.
+                      Example MCO resource is available at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
                     type: boolean
                   enable:
                     default: true

--- a/helm-charts-openshift/Chart.lock
+++ b/helm-charts-openshift/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:25200c34a5cc846a1275e5bf3fc637b19e909dc68de938189c5278d77d03f5ac
-generated: "2025-03-25T06:19:26.060856628Z"
+generated: "2025-03-26T20:10:56.781691243Z"

--- a/helm-charts-openshift/crds/deviceconfig-crd.yaml
+++ b/helm-charts-openshift/crds/deviceconfig-crd.yaml
@@ -346,7 +346,10 @@ spec:
                       installer URL is https://repo.radeon.com/amdgpu-install by default
                     type: string
                   blacklist:
-                    description: blacklist amdgpu drivers on the host
+                    description: |-
+                      blacklist amdgpu drivers on the host. Node reboot is required to apply the baclklist on the worker nodes.
+                      Not working for OpenShift cluster. OpenShift users please use the Machine Config Operator (MCO) resource to configure amdgpu blacklist.
+                      Example MCO resource is available at https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/openshift-olm.html#create-blacklist-for-installing-out-of-tree-kernel-module
                     type: boolean
                   enable:
                     default: true


### PR DESCRIPTION
Optimize the blacklist support for the issue raised in https://github.com/ROCm/gpu-operator/issues/93.

1. For non-OpenShift users nothing is changed
2. For OpenShift users, add more field description to guide them use Machine Config Operator (MCO) to apply the blacklist on OpenShift cluster.
3. For OpenShift users, if any users accidentally configured ```spec.driver.blacklist``` option, use a special blacklist file name so that it won't conflict with MCO blacklist management.