### PR TITLE
Reboot Loop issue if control node needs to go down for driver upgrade

### DIFF
--- a/api/v1alpha1/deviceconfig_types.go
+++ b/api/v1alpha1/deviceconfig_types.go
@@ -597,6 +597,7 @@ type ModuleStatus struct {
 	LastTransitionTime string       `json:"lastTransitionTime,omitempty"`
 	Status             UpgradeState `json:"status,omitempty"`
 	UpgradeStartTime   string       `json:"upgradeStartTime,omitempty"`
+	BootId             string       `json:"bootId,omitempty"`
 }
 
 // DeviceConfigStatus defines the observed state of Module.

--- a/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: AI/Machine Learning,Monitoring
     containerImage: docker.io/rocm/gpu-operator:v1.2.0
-    createdAt: "2025-04-02T23:22:18Z"
+    createdAt: "2025-04-07T07:07:00Z"
     description: |-
       Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
       For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)

--- a/bundle/manifests/amd.com_deviceconfigs.yaml
+++ b/bundle/manifests/amd.com_deviceconfigs.yaml
@@ -931,6 +931,8 @@ spec:
                   description: ModuleStatus contains the status of driver module installed
                     by operator on the node
                   properties:
+                    bootId:
+                      type: string
                     containerImage:
                       type: string
                     kernelVersion:

--- a/config/crd/bases/amd.com_deviceconfigs.yaml
+++ b/config/crd/bases/amd.com_deviceconfigs.yaml
@@ -927,6 +927,8 @@ spec:
                   description: ModuleStatus contains the status of driver module installed
                     by operator on the node
                   properties:
+                    bootId:
+                      type: string
                     containerImage:
                       type: string
                     kernelVersion:

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:f9a315dd2ce3d515ebf28c8e9a6a82158b493ca2686439ec381487761261b597
-generated: "2025-03-26T20:10:45.247725094Z"
+generated: "2025-04-07T07:06:50.661624221Z"

--- a/helm-charts-k8s/crds/deviceconfig-crd.yaml
+++ b/helm-charts-k8s/crds/deviceconfig-crd.yaml
@@ -932,6 +932,8 @@ spec:
                   description: ModuleStatus contains the status of driver module installed
                     by operator on the node
                   properties:
+                    bootId:
+                      type: string
                     containerImage:
                       type: string
                     kernelVersion:

--- a/helm-charts-openshift/Chart.lock
+++ b/helm-charts-openshift/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:25200c34a5cc846a1275e5bf3fc637b19e909dc68de938189c5278d77d03f5ac
-generated: "2025-03-26T20:10:56.781691243Z"
+generated: "2025-04-07T07:06:59.305455465Z"

--- a/helm-charts-openshift/crds/deviceconfig-crd.yaml
+++ b/helm-charts-openshift/crds/deviceconfig-crd.yaml
@@ -932,6 +932,8 @@ spec:
                   description: ModuleStatus contains the status of driver module installed
                     by operator on the node
                   properties:
+                    bootId:
+                      type: string
                     containerImage:
                       type: string
                     kernelVersion:

--- a/internal/controllers/device_config_reconciler.go
+++ b/internal/controllers/device_config_reconciler.go
@@ -593,9 +593,11 @@ func (dcrh *deviceConfigReconcilerHelper) getDeviceConfigOwnedKMMModule(ctx cont
 func (dcrh *deviceConfigReconcilerHelper) updateDeviceConfigNodeStatus(ctx context.Context, devConfig *amdv1alpha1.DeviceConfig, nodes *v1.NodeList) error {
 	logger := log.FromContext(ctx)
 	previousUpgradeTimes := make(map[string]string)
+	previousBootIds := make(map[string]string)
 	// Persist the UpgradeStartTime
 	for nodeName, moduleStatus := range devConfig.Status.NodeModuleStatus {
 		previousUpgradeTimes[nodeName] = moduleStatus.UpgradeStartTime
+		previousBootIds[nodeName] = moduleStatus.BootId
 	}
 	devConfig.Status.NodeModuleStatus = map[string]amdv1alpha1.ModuleStatus{}
 
@@ -610,7 +612,12 @@ func (dcrh *deviceConfigReconcilerHelper) updateDeviceConfigNodeStatus(ctx conte
 		if upgradeStartTime == "" {
 			upgradeStartTime = previousUpgradeTimes[node.Name]
 		}
-		devConfig.Status.NodeModuleStatus[node.Name] = amdv1alpha1.ModuleStatus{Status: dcrh.upgradeMgrHandler.GetNodeStatus(node.Name), UpgradeStartTime: upgradeStartTime}
+		bootId := dcrh.upgradeMgrHandler.GetNodeBootId(node.Name)
+		//If operator restarted during Upgrade, then fetch previous known bootId since the internal maps would have been cleared
+		if bootId == "" {
+			bootId = previousBootIds[node.Name]
+		}
+		devConfig.Status.NodeModuleStatus[node.Name] = amdv1alpha1.ModuleStatus{Status: dcrh.upgradeMgrHandler.GetNodeStatus(node.Name), UpgradeStartTime: upgradeStartTime, BootId: bootId}
 
 		nmc := kmmv1beta1.NodeModulesConfig{}
 		err := dcrh.client.Get(ctx, types.NamespacedName{Name: node.Name}, &nmc)
@@ -632,6 +639,7 @@ func (dcrh *deviceConfigReconcilerHelper) updateDeviceConfigNodeStatus(ctx conte
 						LastTransitionTime: module.LastTransitionTime.String(),
 						Status:             dcrh.upgradeMgrHandler.GetNodeStatus(node.Name),
 						UpgradeStartTime:   upgradeStartTime,
+						BootId:             bootId,
 					}
 				}
 			}

--- a/internal/controllers/mock_upgrademgr.go
+++ b/internal/controllers/mock_upgrademgr.go
@@ -57,6 +57,20 @@ func (m *MockupgradeMgrAPI) EXPECT() *MockupgradeMgrAPIMockRecorder {
 	return m.recorder
 }
 
+// GetNodeBootId mocks base method.
+func (m *MockupgradeMgrAPI) GetNodeBootId(nodeName string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeBootId", nodeName)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetNodeBootId indicates an expected call of GetNodeBootId.
+func (mr *MockupgradeMgrAPIMockRecorder) GetNodeBootId(nodeName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeBootId", reflect.TypeOf((*MockupgradeMgrAPI)(nil).GetNodeBootId), nodeName)
+}
+
 // GetNodeStatus mocks base method.
 func (m *MockupgradeMgrAPI) GetNodeStatus(nodeName string) v1alpha1.UpgradeState {
 	m.ctrl.T.Helper()

--- a/internal/controllers/upgrademgr.go
+++ b/internal/controllers/upgrademgr.go
@@ -74,6 +74,7 @@ type upgradeMgrAPI interface {
 	HandleDelete(ctx context.Context, deviceConfig *amdv1alpha1.DeviceConfig, nodes *v1.NodeList) (ctrl.Result, error)
 	GetNodeStatus(nodeName string) amdv1alpha1.UpgradeState
 	GetNodeUpgradeStartTime(nodeName string) string
+	GetNodeBootId(nodeName string) string
 }
 
 func newUpgradeMgrHandler(client client.Client, k8sConfig *rest.Config) upgradeMgrAPI {
@@ -108,16 +109,25 @@ func (n *upgradeMgr) HandleUpgrade(ctx context.Context, deviceConfig *amdv1alpha
 				if deviceConfig.Spec.Driver.UpgradePolicy.RebootRequired != nil && *deviceConfig.Spec.Driver.UpgradePolicy.RebootRequired {
 					nodeObj, err := n.helper.getNode(ctx, nodeName)
 					if err == nil {
-						log.FromContext(ctx).Info("Reboot is required for driver upgrade, triggering node reboot")
-						n.helper.handleNodeReboot(ctx, nodeObj, deviceConfig)
+						// trigger reboot only for nodes which are in UpgradeStarted but haven't rebooted yet
+						if nodeObj.Status.NodeInfo.BootID == moduleStatus.BootId {
+							log.FromContext(ctx).Info(fmt.Sprintf("Node: %v: Reboot is required for driver upgrade, triggering node reboot", nodeName))
+							n.helper.handleNodeReboot(ctx, nodeObj, deviceConfig)
+							// for nodes which are in UpgradeStarted but already rebooted. Schedule the reboot pod deletion
+						} else {
+							currentBootID := nodeObj.Status.NodeInfo.BootID
+							n.helper.setBootID(nodeObj.Name, currentBootID)
+							log.FromContext(ctx).Info(fmt.Sprintf("Node: %v: Node already rebooted, scheduling reboot pod deletion", nodeName))
+							go n.helper.deleteRebootPod(ctx, nodeName, deviceConfig, false, deviceConfig.Generation)
+						}
 					}
 				} else {
-					log.FromContext(ctx).Info("Resetting Upgrade State to UpgradeStateEmpty")
+					log.FromContext(ctx).Info(fmt.Sprintf("Node: %v: Resetting Upgrade State to UpgradeStateEmpty", nodeName))
 					n.helper.setNodeStatus(ctx, nodeName, amdv1alpha1.UpgradeStateEmpty)
 				}
 			} else if moduleStatus.Status == amdv1alpha1.UpgradeStateRebootInProgress {
 				// Operator restarted during upgrade operation. Schedule the reboot pod deletion
-				log.FromContext(ctx).Info("Reboot is in progress, scheduling reboot pod deletion")
+				log.FromContext(ctx).Info(fmt.Sprintf("Node: %v: Reboot is in progress, scheduling reboot pod deletion", nodeName))
 				n.helper.setNodeStatus(ctx, nodeName, moduleStatus.Status)
 				go n.helper.deleteRebootPod(ctx, nodeName, deviceConfig, false, deviceConfig.Generation)
 			} else {
@@ -244,9 +254,14 @@ func (n *upgradeMgr) GetNodeStatus(nodeName string) (status amdv1alpha1.UpgradeS
 	return n.helper.getNodeStatus(nodeName)
 }
 
-// GetNodeStaGetNodeUpgradeStartTimetus returns the time when upgrade started on the node
+// GetNodeUpgradeStartTime returns the time when upgrade started on the node
 func (n *upgradeMgr) GetNodeUpgradeStartTime(nodeName string) string {
 	return n.helper.getUpgradeStartTime(nodeName)
+}
+
+// GetNodeBootId returns the last known bootid of the node
+func (n *upgradeMgr) GetNodeBootId(nodeName string) string {
+	return n.helper.getBootID(nodeName)
 }
 
 /*=========================================== Upgrade Manager Helper APIs ==========================================*/


### PR DESCRIPTION
Issue: https://pensando.atlassian.net/browse/GPUOP-258

When an automatic upgrade with rebootRequired=true is triggered, nodes are rebooted one by one. If the node hosting the operator pod is rebooted, it kills the operator controller. After reboot, the controller restarts and triggers another reconcile loop, mistakenly thinking the node is still waiting for a reboot since it will be in `UpgradeStarted`, causing a continuous reboot loop

Fix:

-> Recently, we have added support in GPU operator to detect `bootId` change to check for reboot. We will now use this to see if the node has rebooted and not trigger reboot again in those scenarios which will avoid getting into a loop of reboots.

-> If we see that node status is `UpgradeStarted` when operator comes up during init but reboot has happened (happens when node running operator pod in AKS goes down, then update the `bootId` to the new one too and schedule deletion of reboot pod which will continue the rest of the upgrade flow)

Note:
Today the boot Id is stored in internal maps of `upgrademgr`. These will get cleared on reboot. So, exactly the same way `upgradeStartTime` was made part of CR status, we will make bootId part of status too to ensure we have the last known boot id during upgrade and compare the current boot Id against that last known boot id in the module status since the internal map value would have been cleared if operator restarted. (KMM also has persisted this boot ID in its nmc status to detect reboot)

-> Also enhanced some log messages to display node name as well

Verification:

Apply CR for 6.3.1

```
nodeModuleStatus:
    ubuntu2204:
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.1
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:10:30 +0000 UTC
      status: Install-Complete
    worker-1:
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.1
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:10:30 +0000 UTC
      status: Install-Complete
    worker-2:
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.1
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:10:30 +0000 UTC
      status: Install-Complete
```
      
  Upgrade to 6.3.2 with maxparallel set to 2. Master node (where operator pod is running) and worker-1 is picked up

```
nodeModuleStatus:
    ubuntu2204:
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.1
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:10:30 +0000 UTC
      status: Upgrade-Started
      upgradeStartTime: 2025-04-03 11:10:50 UTC
    worker-1:
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.1
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:10:30 +0000 UTC
      status: Upgrade-Started
      upgradeStartTime: 2025-04-03 11:10:50 UTC
    worker-2:
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.1
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:10:30 +0000 UTC
      status: Upgrade-Not-Started
```
After the 2 nodes complete, 3rd one moves to Upgrade-Started

```
nodeModuleStatus:
    ubuntu2204:
      bootId: 33bda474-744d-4688-a3ad-6e21d9ddb316
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.2
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:13:14 +0000 UTC
      status: Upgrade-Complete
      upgradeStartTime: 2025-04-03 11:10:50 UTC
    worker-1:
      bootId: 9d55e327-91d7-4ded-82f8-cddea4f5d6c8
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.2
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:10:58 +0000 UTC
      status: Upgrade-Complete
      upgradeStartTime: 2025-04-03 11:10:50 UTC
    worker-2:
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.2
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:13:37 +0000 UTC
      status: Upgrade-Started
      upgradeStartTime: 2025-04-03 11:13:10 UTC
```

3rd node also moves to Upgrade-Complete eventually

```
nodeModuleStatus:
    ubuntu2204:
      bootId: 33bda474-744d-4688-a3ad-6e21d9ddb316
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.2
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:13:14 +0000 UTC
      status: Upgrade-Complete
      upgradeStartTime: 2025-04-03 11:10:50 UTC
    worker-1:
      bootId: 9d55e327-91d7-4ded-82f8-cddea4f5d6c8
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.2
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:13:49 +0000 UTC
      status: Upgrade-Complete
      upgradeStartTime: 2025-04-03 11:10:50 UTC
    worker-2:
      bootId: c9d141b3-0fa7-45bb-92f2-869a4391521c
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.2
      kernelVersion: 5.15.0-134-generic
      lastTransitionTime: 2025-04-03 11:14:09 +0000 UTC
      status: Upgrade-Complete
      upgradeStartTime: 2025-04-03 11:13:10 UTC
```

We can also see that, now, Operator pod detects that the node was already reboot so doesn't try to reboot the control plane node again and end up in a reboot loop

```
I0403 11:13:10.865523       1 upgrademgr.go:121] "Node: ubuntu2204: Node already rebooted, scheduling reboot pod deletion" logger="amd-gpu" controller="DriverAndPluginReconciler" controllerGroup="amd.com" controllerKind="DeviceConfig" DeviceConfig="kube-amd-gpu/test-deviceconfig" namespace="kube-amd-gpu" name="test-deviceconfig" reconcileID="12ab25df-b69b-4a5c-b03c-3296a50b4b0b"
I0403 11:13:10.865737       1 upgrademgr.go:121] "Node: worker-1: Node already rebooted, scheduling reboot pod deletion" logger="amd-gpu" controller="DriverAndPluginReconciler" controllerGroup="amd.com" controllerKind="DeviceConfig" DeviceConfig="kube-amd-gpu/test-deviceconfig" namespace="kube-amd-gpu" name="test-deviceconfig" reconcileID="12ab25df-b69b-4a5c-b03c-3296a50b4b0b"
```

We can also see that once Operator pod comes back from restart, it is terminating the reboot pod and kmm is loading the driver again
```
kube-amd-gpu   amd-gpu-operator-gpu-operator-charts-controller-manager-779tsj5   1/1     Running       1 (30s ago)     4m4s
kube-amd-gpu   amd-gpu-operator-kmm-controller-7d4685b7b7-dd5fk                  1/1     Running       1 (30s ago)     4m4s
kube-amd-gpu   amd-gpu-operator-kmm-webhook-server-5fdc8b995-vtj68               1/1     Running       1 (30s ago)     4m4s
kube-amd-gpu   amd-gpu-operator-node-feature-discovery-gc-78989c896-pjxbk        1/1     Running       0               4m4s
kube-amd-gpu   amd-gpu-operator-node-feature-discovery-master-b8bffc48b-t9695    1/1     Running       1 (30s ago)     4m4s
kube-amd-gpu   amd-gpu-operator-node-feature-discovery-worker-b7fn9              1/1     Running       0               4m4s
kube-amd-gpu   amd-gpu-operator-node-feature-discovery-worker-mk6jc              1/1     Running       3 (57s ago)     4m4s
kube-amd-gpu   amd-gpu-operator-node-feature-discovery-worker-r285w              1/1     Running       1 (30s ago)     4m4s
kube-amd-gpu   amd-gpu-operator-worker-1-reboot-worker                           1/1     Terminating   0               2m12s
kube-amd-gpu   kmm-worker-ubuntu2204-test-deviceconfig                           0/1     Init:0/1      0               0s
kube-amd-gpu   kmm-worker-worker-1-test-deviceconfig                             0/1     Pending       0               0s
kube-amd-gpu   test-deviceconfig-device-plugin-drldw                             1/1     Running       0               2m40s
kube-amd-gpu   test-deviceconfig-node-labeller-62rtz                             1/1     Running       0               2m44s
kube-amd-gpu   test-deviceconfig-node-labeller-krhkk                             0/1     Unknown       0               2m44s
kube-amd-gpu   test-deviceconfig-node-labeller-ltsfm                             1/1     Running       0               2m44s
```