### PR TITLE
Expose ContainerPort in Metrics Exporter Pod

### DIFF
--- a/internal/metricsexporter/metricsexporter.go
+++ b/internal/metricsexporter/metricsexporter.go
@@ -240,7 +240,7 @@ func (nl *metricsExporter) SetMetricsExporterAsDesired(ds *appsv1.DaemonSet, dev
 		if internalPort == port {
 			internalPort = port - 1
 		}
-		// Bind service port to localhost only
+		// Bind service port to localhost only, don't expose port in ContainerPort
 		containers[0].Args = []string{"--bind=127.0.0.1:" + fmt.Sprintf("%v", int32(internalPort))}
 		containers[0].Env[1].Value = fmt.Sprintf("%v", internalPort)
 
@@ -292,12 +292,26 @@ func (nl *metricsExporter) SetMetricsExporterAsDesired(ds *appsv1.DaemonSet, dev
 			},
 			Args:         args,
 			VolumeMounts: volumeMounts,
+			Ports: []v1.ContainerPort{
+				{
+					Name:          "exporter-port",
+					Protocol:      v1.ProtocolTCP,
+					ContainerPort: port,
+				},
+			},
 		})
 
 		// Provide elevated privilege only when rbac-proxy is enabled
 		serviceaccount = kubeRbacSAName
 	} else {
 		containers[0].Env[1].Value = fmt.Sprintf("%v", port)
+		containers[0].Ports = []v1.ContainerPort{
+			{
+				Name:          "exporter-port",
+				Protocol:      v1.ProtocolTCP,
+				ContainerPort: port,
+			},
+		}
 	}
 
 	gracePeriod := int64(1)


### PR DESCRIPTION
- ContainerPort lists the ports to expose from the Container. Not specifying a port DOES NOT prevent that port from being exposed. The device metrics exporter container starts a metrics server on the port specified by the METRICS_EXPORTER_PORT on the default "0.0.0.0" address in the container which exposes the port. Look at https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/ for more information on this behavior.