### PR TITLE
Change default cpu/memory resource limits for Controller Manager

### DIFF
--- a/docs/installation/kubernetes-helm.md
+++ b/docs/installation/kubernetes-helm.md
@@ -163,6 +163,10 @@ The following parameters are able to be configued when using the Helm Chart. In 
 | controllerManager.manager.image.tag | string | `"v1.2.0"` | AMD GPU operator controller manager image tag |
 | controllerManager.manager.imagePullPolicy | string | `"Always"` | Image pull policy for AMD GPU operator controller manager pod |
 | controllerManager.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image |
+| controllerManager.manager.resources.limits.cpu | string | `"1000m"` | CPU limits for the controller manager. Consider increasing for large clusters |
+| controllerManager.manager.resources.limits.memory | string | `"1Gi"` | Memory limits for the controller manager. Consider increasing if experiencing OOM issues |
+| controllerManager.manager.resources.requests.cpu | string | `"100m"` | CPU requests for the controller manager. Adjust based on observed CPU usage |
+| controllerManager.manager.resources.requests.memory | string | `"256Mi"` | Memory requests for the controller manager. Adjust based on observed memory usage |
 | controllerManager.nodeSelector | object | `{}` | Node selector for AMD GPU operator controller manager deployment |
 | installdefaultNFDRule | bool | `true` | Default NFD rule will detect amd gpu based on pci vendor ID |
 | kmm.enabled | bool | `true` | Set to true/false to enable/disable the installation of kernel module management (KMM) operator |
@@ -256,6 +260,42 @@ Verify that nodes with AMD GPU hardware are properly labeled:
 
 ```bash
 kubectl get nodes -L feature.node.kubernetes.io/amd-gpu
+```
+
+## Resource Configuration
+
+### Controller Manager Resource Settings
+
+The AMD GPU Operator controller manager component has default resource limits and requests configured for typical usage scenarios. You may need to adjust these values based on your specific cluster environment:
+
+```yaml
+controllerManager:
+  manager:
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+```
+
+#### When to Adjust Resource Settings
+
+You should consider adjusting the controller manager resource settings in these scenarios:
+
+- **Large clusters**: If managing a large number of nodes or GPU devices, consider increasing both CPU and memory limits
+- **Memory pressure**: If you observe OOM (Out of Memory) kills in controller manager pods, increase the memory limit and request
+- **CPU pressure**: If the controller manager is experiencing throttling or slow response times during operations, increase the CPU limit and request
+- **Resource-constrained environments**: For smaller development or test clusters, you may reduce these values to conserve resources
+
+You can apply resource changes by updating your values.yaml file and upgrading the Helm release:
+
+```bash
+helm upgrade amd-gpu-operator amd/gpu-operator-helm \
+  --namespace kube-amd-gpu \
+  --version=v1.0.0 \
+  -f values.yaml
 ```
 
 ## Install Custom Resource

--- a/hack/k8s-patch/metadata-patch/values.yaml
+++ b/hack/k8s-patch/metadata-patch/values.yaml
@@ -47,11 +47,11 @@ controllerManager:
       effect: "NoSchedule"
     resources:
       limits:
-        cpu: 500m
-        memory: 384Mi
+        cpu: 1000m
+        memory: 1Gi
       requests:
-        cpu: 10m
-        memory: 64Mi
+        cpu: 100m
+        memory: 256Mi
   # -- Node selector for AMD GPU operator controller manager deployment
   nodeSelector: {}
   # -- Deployment affinity configs for controller manager

--- a/hack/openshift-patch/metadata-patch/values.yaml
+++ b/hack/openshift-patch/metadata-patch/values.yaml
@@ -26,11 +26,11 @@ controllerManager:
       effect: "NoSchedule"
     resources:
       limits:
-        cpu: 500m
-        memory: 384Mi
+        cpu: 1000m
+        memory: 1Gi
       requests:
-        cpu: 10m
-        memory: 64Mi
+        cpu: 100m
+        memory: 256Mi
   nodeSelector: {}
   affinity:
     nodeAffinity:

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -47,11 +47,11 @@ controllerManager:
       effect: "NoSchedule"
     resources:
       limits:
-        cpu: 500m
-        memory: 384Mi
+        cpu: 1000m
+        memory: 1Gi
       requests:
-        cpu: 10m
-        memory: 64Mi
+        cpu: 100m
+        memory: 256Mi
   # -- Node selector for AMD GPU operator controller manager deployment
   nodeSelector: {}
   # -- Deployment affinity configs for controller manager

--- a/helm-charts-openshift/values.yaml
+++ b/helm-charts-openshift/values.yaml
@@ -26,11 +26,11 @@ controllerManager:
       effect: "NoSchedule"
     resources:
       limits:
-        cpu: 500m
-        memory: 384Mi
+        cpu: 1000m
+        memory: 1Gi
       requests:
-        cpu: 10m
-        memory: 64Mi
+        cpu: 100m
+        memory: 256Mi
   nodeSelector: {}
   affinity:
     nodeAffinity:


### PR DESCRIPTION
For larger deployments, the default CPU limits of 500m (half a core) and memory limit of 384Mi in the cluster might be insufficient. It has been bumped up with this change and documentation has been added to alert the user to modify these values in helm if they have larger clusters.