### PR TITLE
feat: switch nodeaffinity from required to prefer for OLM

### DIFF
--- a/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -1016,7 +1016,7 @@ spec:
             spec:
               affinity:
                 nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
+                  preferredDuringSchedulingIgnoredDuringExecution:
                     nodeSelectorTerms:
                     - matchExpressions:
                       - key: node-role.kubernetes.io/control-plane

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
This is related to: https://github.com/ROCm/gpu-operator/issues/129

There are a few ways to address this issue, but here is one idea - to switch nodeaffinity from Required to Preferred.

I did not update the Helm charts, as those appear to have a different flow (and do have a path to override nodeAffinity). However, I can add those to this PR as well.