### PR TITLE
GPU Operator v1.2.1 release changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ endif
 
 # PROJECT_VERSION defines the project version.
 # Update this value when you upgrade the version of your project.
-PROJECT_VERSION ?= v1.2.0
+PROJECT_VERSION ?= v1.2.1
 
 ####################################
 # GPU Operator Image Build variables

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Basic installation:
 helm install amd-gpu-operator rocm/gpu-operator-charts \
   --namespace kube-amd-gpu \
   --create-namespace \
-  --version=v1.2.0
+  --version=v1.2.1
 ```
 
 ```{note}
@@ -93,7 +93,7 @@ Following dashboards are provided for visualizing GPU metrics collected from dev
 
 ## Contributing
 
-Please refer to our [Developer Guide](https://instinct.docs.amd.com/projects/gpu-operator/en/release-v1.2.0/contributing/developer-guide.html).
+Please refer to our [Developer Guide](https://instinct.docs.amd.com/projects/gpu-operator/en/release-v1.2.1/contributing/developer-guide.html).
 
 ## Support
 

--- a/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/ROCm/gpu-operator
-  name: amd-gpu-operator.v1.2.0
+  name: amd-gpu-operator.v1.2.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -906,7 +906,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: docker.io/rocm/gpu-operator:v1.2.0
+                image: docker.io/rocm/gpu-operator:v1.2.1
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/config/manager-base/kustomization.yaml
+++ b/config/manager-base/kustomization.yaml
@@ -10,7 +10,7 @@ patches:
 images:
 - name: controller
   newName: docker.io/rocm/gpu-operator
-  newTag: v1.2.0
+  newTag: v1.2.1
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
 - name: controller
   newName: docker.io/rocm/gpu-operator
-  newTag: v1.2.0
+  newTag: v1.2.1
 
 configMapGenerator:
 - files:

--- a/docs/drivers/installation.md
+++ b/docs/drivers/installation.md
@@ -69,7 +69,7 @@ spec:
      serviceType: "NodePort"
      # Node port for metrics exporter service, metrics endpoint $node-ip:$nodePort
      nodePort: 32500
-     image: docker.io/rocm/device-metrics-exporter:v1.2.0
+     image: docker.io/rocm/device-metrics-exporter:v1.2.1
 
   # Specifythe node to be managed by this DeviceConfig Custom Resource
   selector:
@@ -119,7 +119,7 @@ spec:
      serviceType: "NodePort"
      # Node port for metrics exporter service, metrics endpoint $node-ip:$nodePort
      nodePort: 32500
-     image: docker.io/rocm/device-metrics-exporter:v1.2.0
+     image: docker.io/rocm/device-metrics-exporter:v1.2.1
 
   # Specifythe node to be managed by this DeviceConfig Custom Resource
   selector:

--- a/docs/fulldeviceconfig.rst
+++ b/docs/fulldeviceconfig.rst
@@ -119,7 +119,7 @@ Below is an example of a full DeviceConfig CR that can be used to install the AM
         serviceType: ClusterIP # ServiceType used to expose the Metrics Exporter endpoint. Can be either `ClusterIp` or `NodePort`.
         port: 5000 # Note if specifying NodePort as the serviceType use `32500` as the port number must be between 30000-32767
         # (Optional) Specifying metrics exporter image is optional. Default imagename shown here if not specified.
-        image: rocm/device-metrics-exporter:v1.2.0 # Change this to trigger metrics exporter upgrade on CR update
+        image: rocm/device-metrics-exporter:v1.2.1 # Change this to trigger metrics exporter upgrade on CR update
         imagePullPolicy: "IfNotPresent" # image pull policy for the metrics exporter container. Either `Always`, `IfNotPresent` or `Never`
         # imagePullPolicy default value is "IfNotPresent" for valid tags, "Always" for no tag or "latest" tag
         config:
@@ -162,7 +162,7 @@ Below is an example of a full DeviceConfig CR that can be used to install the AM
         serviceType: ClusterIP # ServiceType used to expose the Metrics Exporter endpoint. Can be either `ClusterIp` or `NodePort`.
         port: 5000 # Note if specifying NodePort as the serviceType use `32500` as the port number must be between 30000-32767
         # (Optional) Specifying metrics exporter image is optional. Default imagename shown here if not specified.
-        image: docker.io/rocm/test-runner:v1.2.0-beta.0 # Change this to trigger metrics exporter upgrade on CR update
+        image: docker.io/rocm/test-runner:v1.2.1-beta.0 # Change this to trigger metrics exporter upgrade on CR update
         imagePullPolicy: "IfNotPresent" # image pull policy for the test runner container. Either `Always`, `IfNotPresent` or `Never`
         # imagePullPolicy default value is "IfNotPresent" for valid tags, "Always" for no tag or "latest" tag
         config:

--- a/docs/installation/kubernetes-helm.md
+++ b/docs/installation/kubernetes-helm.md
@@ -159,7 +159,7 @@ The following parameters are able to be configued when using the Helm Chart. In 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | controllerManager.manager.image.repository | string | `"docker.io/rocm/gpu-operator"` | AMD GPU operator controller manager image repository |
-| controllerManager.manager.image.tag | string | `"v1.2.0"` | AMD GPU operator controller manager image tag |
+| controllerManager.manager.image.tag | string | `"v1.2.1"` | AMD GPU operator controller manager image tag |
 | controllerManager.manager.imagePullPolicy | string | `"Always"` | Image pull policy for AMD GPU operator controller manager pod |
 | controllerManager.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image |
 | controllerManager.nodeAffinity.nodeSelectorTerms | list | `[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}, {"key":"node-role.kubernetes.io/master","operator":"Exists"}]` | Node affinity selector terms config for the AMD GPU operator controller manager, set it to [] if you want to make affinity config empty |
@@ -167,12 +167,12 @@ The following parameters are able to be configued when using the Helm Chart. In 
 | installdefaultNFDRule | bool | `true` | Set to true to install default NFD rule for detecting AMD GPU hardware based on pci vendor ID and device ID |
 | kmm.controller.manager.env.relatedImageBuild | string | `"gcr.io/kaniko-project/executor:v1.23.2"` | KMM kaniko builder image for building driver image within cluster |
 | kmm.controller.manager.env.relatedImageBuildPullSecret | string | `""` | Image pull secret name for pulling KMM kaniko builder image if registry needs credential to pull image |
-| kmm.controller.manager.env.relatedImageSign | string | `"docker.io/rocm/kernel-module-management-signimage:v1.2.0"` | KMM signer image for signing driver image's kernel module with given key pairs within cluster |
+| kmm.controller.manager.env.relatedImageSign | string | `"docker.io/rocm/kernel-module-management-signimage:v1.2.1"` | KMM signer image for signing driver image's kernel module with given key pairs within cluster |
 | kmm.controller.manager.env.relatedImageSignPullSecret | string | `""` | Image pull secret name for pulling KMM signer image if registry needs credential to pull image |
-| kmm.controller.manager.env.relatedImageWorker | string | `"docker.io/rocm/kernel-module-management-worker:v1.2.0"` | KMM worker image for loading / unloading driver kernel module on worker nodes |
+| kmm.controller.manager.env.relatedImageWorker | string | `"docker.io/rocm/kernel-module-management-worker:v1.2.1"` | KMM worker image for loading / unloading driver kernel module on worker nodes |
 | kmm.controller.manager.env.relatedImageWorkerPullSecret | string | `""` | Image pull secret name for pulling KMM worker image if registry needs credential to pull image |
 | kmm.controller.manager.image.repository | string | `"docker.io/rocm/kernel-module-management-operator"` | KMM controller manager image repository |
-| kmm.controller.manager.image.tag | string | `"v1.2.0"` | KMM controller manager image tag |
+| kmm.controller.manager.image.tag | string | `"v1.2.1"` | KMM controller manager image tag |
 | kmm.controller.manager.imagePullPolicy | string | `"Always"` | Image pull policy for KMM controller manager pod |
 | kmm.controller.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling KMM controller manager image if registry needs credential to pull image |
 | kmm.controller.nodeAffinity.nodeSelectorTerms | list | `[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}, {"key":"node-role.kubernetes.io/master","operator":"Exists"}]` | Node affinity selector terms config for the KMM controller manager deployment, set it to [] if you want to make affinity config empty |
@@ -181,7 +181,7 @@ The following parameters are able to be configued when using the Helm Chart. In 
 | kmm.webhookServer.nodeAffinity.nodeSelectorTerms | list | `[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}, {"key":"node-role.kubernetes.io/master","operator":"Exists"}]` | Node affinity selector terms config for the KMM webhook deployment, set it to [] if you want to make affinity config empty |
 | kmm.webhookServer.nodeSelector | object | `{}` | KMM webhook's deployment node selector |
 | kmm.webhookServer.webhookServer.image.repository | string | `"docker.io/rocm/kernel-module-management-webhook-server"` | KMM webhook image repository |
-| kmm.webhookServer.webhookServer.image.tag | string | `"v1.2.0"` | KMM webhook image tag |
+| kmm.webhookServer.webhookServer.image.tag | string | `"v1.2.1"` | KMM webhook image tag |
 | kmm.webhookServer.webhookServer.imagePullPolicy | string | `"Always"` | Image pull policy for KMM webhook pod |
 | kmm.webhookServer.webhookServer.imagePullSecrets | string | `""` | Image pull secret name for pulling KMM webhook image if registry needs credential to pull image |
 | node-feature-discovery.enabled | bool | `true` | Set to true/false to enable/disable the installation of node feature discovery (NFD) operator |
@@ -242,7 +242,7 @@ spec:
      serviceType: "NodePort"
      # Node port for metrics exporter service, metrics endpoint $node-ip:$nodePort
      nodePort: 32500
-     image: docker.io/rocm/device-metrics-exporter:v1.2.0
+     image: docker.io/rocm/device-metrics-exporter:v1.2.1
 
   # Specifythe node to be managed by this DeviceConfig Custom Resource
   selector:
@@ -292,7 +292,7 @@ spec:
      serviceType: "NodePort"
      # Node port for metrics exporter service, metrics endpoint $node-ip:$nodePort
      nodePort: 32500
-     image: docker.io/rocm/device-metrics-exporter:v1.2.0
+     image: docker.io/rocm/device-metrics-exporter:v1.2.1
 
   # Specifythe node to be managed by this DeviceConfig Custom Resource
   selector:

--- a/docs/metrics/exporter.md
+++ b/docs/metrics/exporter.md
@@ -17,7 +17,7 @@ metricsExporter:
     nodePort: 32500
 
     # image for the metrics-exporter container
-    image: "rocm/device-metrics-exporter:v1.2.0"
+    image: "rocm/device-metrics-exporter:v1.2.1"
  
 ```
 

--- a/docs/metrics/health.md
+++ b/docs/metrics/health.md
@@ -12,9 +12,9 @@ cluster with health check feature if configured to include both device plugin an
 
 ## Requirements
 
-1. metrics exporter : v1.2.0 and up
+1. metrics exporter : v1.2.1 and up
 2. k8s-device-plugin : latest
-3. gpu operator : v1.2.0 and up
+3. gpu operator : v1.2.1 and up
 
 ## Health Check Workflow
 

--- a/docs/test/auto-unhealthy-device-test.md
+++ b/docs/test/auto-unhealthy-device-test.md
@@ -21,7 +21,7 @@ metricsExporter:
     nodePort: 32500
 
     # image for the metrics-exporter container
-    image: "rocm/device-metrics-exporter:v1.2.0"
+    image: "rocm/device-metrics-exporter:v1.2.1"
 
 # Specify the test runner config
 testRunner:
@@ -29,7 +29,7 @@ testRunner:
     enable: true
 
     # image for the test runner container
-    image: docker.io/rocm/test-runner:v1.2.0-beta.0
+    image: docker.io/rocm/test-runner:v1.2.1-beta.0
 
     # specify the mount for test logs
     logsLocation:

--- a/docs/test/manual-test.md
+++ b/docs/test/manual-test.md
@@ -72,7 +72,7 @@ spec:
           type: Directory
       containers:
       - name: amd-test-runner
-        image: docker.io/rocm/test-runner:v1.2.0-beta.0
+        image: docker.io/rocm/test-runner:v1.2.1-beta.0
         imagePullPolicy: IfNotPresent
         securityContext: # setup security context for container to get access to device related interfaces
           privileged: true
@@ -163,7 +163,7 @@ spec:
           limits:
             amd.com/gpu: 8 # requesting all GPUs on the node
         name: amd-test-runner
-        image: docker.io/rocm/test-runner:v1.2.0-beta.0
+        image: docker.io/rocm/test-runner:v1.2.1-beta.0
         imagePullPolicy: IfNotPresent
         env:
         - name: TEST_TRIGGER
@@ -280,7 +280,7 @@ spec:
               type: Directory
           containers:
           - name: init-test-runner
-            image: docker.io/rocm/test-runner:v1.2.0-beta.0
+            image: docker.io/rocm/test-runner:v1.2.1-beta.0
             imagePullPolicy: IfNotPresent
             securityContext: # setup security context for container to get access to device related interfaces
               privileged: true
@@ -463,7 +463,7 @@ spec:
           name: manual-config-map
       containers:
       - name: amd-test-runner
-        image: docker.io/rocm/test-runner:v1.2.0-beta.0
+        image: docker.io/rocm/test-runner:v1.2.1-beta.0
         imagePullPolicy: IfNotPresent
         securityContext: # setup security context for container to get access to device related interfaces
           privileged: true
@@ -619,7 +619,7 @@ spec:
         name: test-runner-volume
       containers:
       - name: amd-test-runner
-        image: docker.io/rocm/test-runner:v1.2.0-beta.0
+        image: docker.io/rocm/test-runner:v1.2.1-beta.0
         imagePullPolicy: IfNotPresent
         securityContext: # setup security context for container to get access to device related interfaces
           privileged: true

--- a/docs/test/pre-start-job-test.md
+++ b/docs/test/pre-start-job-test.md
@@ -78,7 +78,7 @@ spec:
       serviceAccountName: test-run
       initContainers:
       - name: init-test-runner
-        image: docker.io/rocm/test-runner:v1.2.0-beta.0
+        image: docker.io/rocm/test-runner:v1.2.1-beta.0
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/docs/upgrades/componentupgrades.md
+++ b/docs/upgrades/componentupgrades.md
@@ -121,7 +121,7 @@ Updated CR:
     enable: True
     serviceType: "ClusterIP"
     port: 5000
-    image: rocm/device-metrics-exporter:v1.2.0
+    image: rocm/device-metrics-exporter:v1.2.1
     upgradePolicy:
       upgradeStrategy: OnDelete
 ```

--- a/docs/upgrades/upgrade.md
+++ b/docs/upgrades/upgrade.md
@@ -59,10 +59,10 @@ To resolve:
 
 ### 3. Perform the Upgrade
 
-Upgrade the operator using the following command making sure to specify what version you want to updgrade to (v1.2.0 in this example):
+Upgrade the operator using the following command making sure to specify what version you want to updgrade to (v1.2.1 in this example):
 
 ```bash
-helm upgrade amd-gpu-operator rocm/gpu-operator-charts -n kube-amd-gpu --version=v1.2.0
+helm upgrade amd-gpu-operator rocm/gpu-operator-charts -n kube-amd-gpu --version=v1.2.1
 ```
 
 - The ```fullnameOverride``` and ```nameOverride``` parameters are used to ensure consistent naming between the previous and new chart deployments, avoiding conflicts caused by name mismatches during the upgrade process. The ```fullnameOverride``` explicitly sets the fully qualified name of the resources created by the chart, such as service accounts and deployments. The ```nameOverride``` adjusts the base name of the chart without affecting resource-specific names.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,12 +34,12 @@ Getting up and running with the AMD GPU Operator and Device Metrics Exporter on 
       --namespace kube-amd-gpu --create-namespace
     ```
 
-    Optionally, you can use the Helm `--version` parameter to install a specific version of the GPU Operator (v1.2.0 in this case) as follows:
+    Optionally, you can use the Helm `--version` parameter to install a specific version of the GPU Operator (v1.2.1 in this case) as follows:
 
     ```bash
     helm install amd-gpu-operator rocm/gpu-operator-charts \
       --namespace kube-amd-gpu --create-namespace \
-      --version=v1.2.0
+      --version=v1.2.1
     ```
 
     </br>

--- a/example/deviceconfig_example.yaml
+++ b/example/deviceconfig_example.yaml
@@ -77,7 +77,7 @@ spec:
     nodePort: 32500
 
     # exporter image
-    image: docker.io/rocm/device-metrics-exporter:v1.2.0
+    image: docker.io/rocm/device-metrics-exporter:v1.2.1
 
     # image pull secrets for fetching metrics exporter image
     #imageRegistrySecret:
@@ -94,7 +94,7 @@ spec:
     enable: True
 
     # testrunner image
-    image: docker.io/rocm/test-runner:v1.2.0-beta.0
+    image: docker.io/rocm/test-runner:v1.2.1-beta.0
 
     # image pull policy for the testrunner
     # default value is IfNotPresent for valid tags, Always for no tag or "latest" tag

--- a/example/metricsExporter/deviceconfig_example.yaml
+++ b/example/metricsExporter/deviceconfig_example.yaml
@@ -44,7 +44,7 @@ spec:
     nodePort: 32500
 
     # image for the metrics-exporter container
-    image: "docker.io/rocm/device-metrics-exporter:v1.2.0"
+    image: "docker.io/rocm/device-metrics-exporter:v1.2.1"
     
     # Specify the kube-rbac-proxy config
     rbacConfig:

--- a/example/testrunner/manual_test_job.yaml
+++ b/example/testrunner/manual_test_job.yaml
@@ -112,7 +112,7 @@ spec:
         name: test-runner-volume
       containers:
       - name: amd-test-runner
-        image: docker.io/rocm/test-runner:v1.2.0-beta.0
+        image: docker.io/rocm/test-runner:v1.2.1-beta.0
         imagePullPolicy: IfNotPresent
         securityContext: # setup security context for container to get access to device related interfaces
           privileged: true

--- a/example/testrunner/pre_start_job_check.yaml
+++ b/example/testrunner/pre_start_job_check.yaml
@@ -107,7 +107,7 @@ spec:
           name: pre-job-test-config-map
       initContainers:
       - name: init-test-runner
-        image: docker.io/rocm/test-runner:v1.2.0-beta.0
+        image: docker.io/rocm/test-runner:v1.2.1-beta.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/example/testrunner/schedule_test_cronjob.yaml
+++ b/example/testrunner/schedule_test_cronjob.yaml
@@ -111,7 +111,7 @@ spec:
               name: manual-scheduled-config-map
           containers:
           - name: init-test-runner
-            image: docker.io/rocm/test-runner:v1.2.0-beta.0
+            image: docker.io/rocm/test-runner:v1.2.1-beta.0
             imagePullPolicy: IfNotPresent
             securityContext: # setup security context for container to get access to device related interfaces
               privileged: true

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/gofuzz v1.2.1 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.1 // indirect
@@ -80,7 +80,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/xlab/treeprint v1.2.0 // indirect
+	github.com/xlab/treeprint v1.2.1 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.14.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/gofuzz v1.2.1 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.1 // indirect
@@ -80,7 +80,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/xlab/treeprint v1.2.1 // indirect
+	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,7 +56,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v1.2.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -83,8 +83,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gofuzz v1.2.1 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
-github.com/google/gofuzz v1.2.1/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
@@ -181,8 +181,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/xlab/treeprint v1.2.1 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
-github.com/xlab/treeprint v1.2.1/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -56,7 +56,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.2.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -83,8 +83,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
-github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.1 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.1/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
@@ -181,8 +181,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
-github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/xlab/treeprint v1.2.1 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.1/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/hack/k8s-patch/k8s-kmm-patch/metadata-patch/values.yaml
+++ b/hack/k8s-patch/k8s-kmm-patch/metadata-patch/values.yaml
@@ -8,9 +8,9 @@ controller:
       # -- KMM kaniko builder image for building driver image within cluster
       relatedImageBuild: gcr.io/kaniko-project/executor:v1.23.2
       # -- KMM signer image for signing driver image's kernel module with given key pairs within cluster
-      relatedImageSign: docker.io/rocm/kernel-module-management-signimage:v1.2.0
+      relatedImageSign: docker.io/rocm/kernel-module-management-signimage:v1.2.1
       # -- KMM worker image for loading / unloading driver kernel module on worker nodes
-      relatedImageWorker: docker.io/rocm/kernel-module-management-worker:v1.2.0
+      relatedImageWorker: docker.io/rocm/kernel-module-management-worker:v1.2.1
       # -- Image pull secret name for pulling KMM kaniko builder image if registry needs credential to pull image
       relatedImageBuildPullSecret: ""
       # -- Image pull secret name for pulling KMM signer image if registry needs credential to pull image
@@ -21,7 +21,7 @@ controller:
       # -- KMM controller manager image repository
       repository: docker.io/rocm/kernel-module-management-operator
       # -- KMM controller manager image tag
-      tag: v1.2.0
+      tag: v1.2.1
     # -- Image pull policy for KMM controller manager pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling KMM controller manager image if registry needs credential to pull image
@@ -104,7 +104,7 @@ webhookServer:
       # -- KMM webhook image repository
       repository: docker.io/rocm/kernel-module-management-webhook-server
       # -- KMM webhook image tag
-      tag: v1.2.0
+      tag: v1.2.1
     # -- Image pull policy for KMM webhook pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling KMM webhook image if registry needs credential to pull image

--- a/hack/k8s-patch/metadata-patch/Chart.yaml
+++ b/hack/k8s-patch/metadata-patch/Chart.yaml
@@ -19,8 +19,8 @@ keywords:
   - monitoring
 
 kubeVersion: ">= 1.29.0-0"
-version: v1.2.0
-appVersion: "v1.2.0"
+version: v1.2.1
+appVersion: "v1.2.1"
 
 dependencies:
 - name: node-feature-discovery

--- a/hack/k8s-patch/metadata-patch/values.yaml
+++ b/hack/k8s-patch/metadata-patch/values.yaml
@@ -25,7 +25,7 @@ controllerManager:
       # -- AMD GPU operator controller manager image repository
       repository: docker.io/rocm/gpu-operator
       # -- AMD GPU operator controller manager image tag
-      tag: v1.2.0
+      tag: v1.2.1
     # -- Image pull policy for AMD GPU operator controller manager pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image

--- a/hack/openshift-patch/metadata-patch/Chart.yaml
+++ b/hack/openshift-patch/metadata-patch/Chart.yaml
@@ -19,8 +19,8 @@ keywords:
   - monitoring
 
 kubeVersion: ">= 1.29.0-0"
-version: v1.2.0
-appVersion: "v1.2.0"
+version: v1.2.1
+appVersion: "v1.2.1"
 
 dependencies:
 - name: nfd

--- a/hack/openshift-patch/metadata-patch/values.yaml
+++ b/hack/openshift-patch/metadata-patch/values.yaml
@@ -12,7 +12,7 @@ controllerManager:
       allowPrivilegeEscalation: false
     image:
       repository: docker.io/rocm/gpu-operator
-      tag: v1.2.0
+      tag: v1.2.1
     imagePullPolicy: Always
     imagePullSecrets: ""
     tolerations:

--- a/helm-charts-k8s/Chart.yaml
+++ b/helm-charts-k8s/Chart.yaml
@@ -19,8 +19,8 @@ keywords:
   - monitoring
 
 kubeVersion: ">= 1.29.0-0"
-version: v1.2.0
-appVersion: "v1.2.0"
+version: v1.2.1
+appVersion: "v1.2.1"
 
 dependencies:
 - name: node-feature-discovery

--- a/helm-charts-k8s/README.md
+++ b/helm-charts-k8s/README.md
@@ -65,7 +65,7 @@ Basic installation:
 helm install amd-gpu-operator rocm/gpu-operator-charts \
   --namespace kube-amd-gpu \
   --create-namespace \
-  --version=v1.2.0
+  --version=v1.2.1
 ```
 
 ```{note}
@@ -105,7 +105,7 @@ The AMD GPU Operator is licensed under the [Apache License 2.0](LICENSE).
 
 ## gpu-operator-charts
 
-![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
+![Version: v1.2.1](https://img.shields.io/badge/Version-v1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.1](https://img.shields.io/badge/AppVersion-v1.2.1-informational?style=flat-square)
 
 AMD GPU Operator simplifies the deployment and management of AMD Instinct GPU accelerators within Kubernetes clusters.
 
@@ -136,7 +136,7 @@ Kubernetes: `>= 1.29.0-0`
 |-----|------|---------|-------------|
 | controllerManager.affinity | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]},"weight":1}]}}` | Deployment affinity configs for controller manager |
 | controllerManager.manager.image.repository | string | `"docker.io/rocm/gpu-operator"` | AMD GPU operator controller manager image repository |
-| controllerManager.manager.image.tag | string | `"v1.2.0"` | AMD GPU operator controller manager image tag |
+| controllerManager.manager.image.tag | string | `"v1.2.1"` | AMD GPU operator controller manager image tag |
 | controllerManager.manager.imagePullPolicy | string | `"Always"` | Image pull policy for AMD GPU operator controller manager pod |
 | controllerManager.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image |
 | controllerManager.nodeSelector | object | `{}` | Node selector for AMD GPU operator controller manager deployment |
@@ -149,12 +149,12 @@ Kubernetes: `>= 1.29.0-0`
 | kmm.controller.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | kmm.controller.manager.env.relatedImageBuild | string | `"gcr.io/kaniko-project/executor:v1.23.2"` | KMM kaniko builder image for building driver image within cluster |
 | kmm.controller.manager.env.relatedImageBuildPullSecret | string | `""` | Image pull secret name for pulling KMM kaniko builder image if registry needs credential to pull image |
-| kmm.controller.manager.env.relatedImageSign | string | `"docker.io/rocm/kernel-module-management-signimage:v1.2.0"` | KMM signer image for signing driver image's kernel module with given key pairs within cluster |
+| kmm.controller.manager.env.relatedImageSign | string | `"docker.io/rocm/kernel-module-management-signimage:v1.2.1"` | KMM signer image for signing driver image's kernel module with given key pairs within cluster |
 | kmm.controller.manager.env.relatedImageSignPullSecret | string | `""` | Image pull secret name for pulling KMM signer image if registry needs credential to pull image |
-| kmm.controller.manager.env.relatedImageWorker | string | `"docker.io/rocm/kernel-module-management-worker:v1.2.0"` | KMM worker image for loading / unloading driver kernel module on worker nodes |
+| kmm.controller.manager.env.relatedImageWorker | string | `"docker.io/rocm/kernel-module-management-worker:v1.2.1"` | KMM worker image for loading / unloading driver kernel module on worker nodes |
 | kmm.controller.manager.env.relatedImageWorkerPullSecret | string | `""` | Image pull secret name for pulling KMM worker image if registry needs credential to pull image |
 | kmm.controller.manager.image.repository | string | `"docker.io/rocm/kernel-module-management-operator"` | KMM controller manager image repository |
-| kmm.controller.manager.image.tag | string | `"v1.2.0"` | KMM controller manager image tag |
+| kmm.controller.manager.image.tag | string | `"v1.2.1"` | KMM controller manager image tag |
 | kmm.controller.manager.imagePullPolicy | string | `"Always"` | Image pull policy for KMM controller manager pod |
 | kmm.controller.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling KMM controller manager image if registry needs credential to pull image |
 | kmm.controller.manager.resources.limits.cpu | string | `"500m"` |  |
@@ -188,7 +188,7 @@ Kubernetes: `>= 1.29.0-0`
 | kmm.webhookServer.webhookServer.args[3] | string | `"--enable-preflightvalidation"` |  |
 | kmm.webhookServer.webhookServer.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | kmm.webhookServer.webhookServer.image.repository | string | `"docker.io/rocm/kernel-module-management-webhook-server"` | KMM webhook image repository |
-| kmm.webhookServer.webhookServer.image.tag | string | `"v1.2.0"` | KMM webhook image tag |
+| kmm.webhookServer.webhookServer.image.tag | string | `"v1.2.1"` | KMM webhook image tag |
 | kmm.webhookServer.webhookServer.imagePullPolicy | string | `"Always"` | Image pull policy for KMM webhook pod |
 | kmm.webhookServer.webhookServer.imagePullSecrets | string | `""` | Image pull secret name for pulling KMM webhook image if registry needs credential to pull image |
 | kmm.webhookServer.webhookServer.resources.limits.cpu | string | `"500m"` |  |

--- a/helm-charts-k8s/charts/kmm/values.yaml
+++ b/helm-charts-k8s/charts/kmm/values.yaml
@@ -8,9 +8,9 @@ controller:
       # -- KMM kaniko builder image for building driver image within cluster
       relatedImageBuild: gcr.io/kaniko-project/executor:v1.23.2
       # -- KMM signer image for signing driver image's kernel module with given key pairs within cluster
-      relatedImageSign: docker.io/rocm/kernel-module-management-signimage:v1.2.0
+      relatedImageSign: docker.io/rocm/kernel-module-management-signimage:v1.2.1
       # -- KMM worker image for loading / unloading driver kernel module on worker nodes
-      relatedImageWorker: docker.io/rocm/kernel-module-management-worker:v1.2.0
+      relatedImageWorker: docker.io/rocm/kernel-module-management-worker:v1.2.1
       # -- Image pull secret name for pulling KMM kaniko builder image if registry needs credential to pull image
       relatedImageBuildPullSecret: ""
       # -- Image pull secret name for pulling KMM signer image if registry needs credential to pull image
@@ -21,7 +21,7 @@ controller:
       # -- KMM controller manager image repository
       repository: docker.io/rocm/kernel-module-management-operator
       # -- KMM controller manager image tag
-      tag: v1.2.0
+      tag: v1.2.1
     # -- Image pull policy for KMM controller manager pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling KMM controller manager image if registry needs credential to pull image
@@ -104,7 +104,7 @@ webhookServer:
       # -- KMM webhook image repository
       repository: docker.io/rocm/kernel-module-management-webhook-server
       # -- KMM webhook image tag
-      tag: v1.2.0
+      tag: v1.2.1
     # -- Image pull policy for KMM webhook pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling KMM webhook image if registry needs credential to pull image

--- a/helm-charts-k8s/crds/deviceconfig-crd.yaml
+++ b/helm-charts-k8s/crds/deviceconfig-crd.yaml
@@ -9,10 +9,10 @@ metadata:
   labels:
     app.kubernetes.io/component: amd-gpu
     app.kubernetes.io/part-of: amd-gpu
-    helm.sh/chart: gpu-operator-charts-v1.2.0
+    helm.sh/chart: gpu-operator-charts-v1.2.1
     app.kubernetes.io/name: gpu-operator-charts
     app.kubernetes.io/instance: amd-gpu
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   group: amd.com

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -25,7 +25,7 @@ controllerManager:
       # -- AMD GPU operator controller manager image repository
       repository: docker.io/rocm/gpu-operator
       # -- AMD GPU operator controller manager image tag
-      tag: v1.2.0
+      tag: v1.2.1
     # -- Image pull policy for AMD GPU operator controller manager pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image

--- a/helm-charts-openshift/Chart.yaml
+++ b/helm-charts-openshift/Chart.yaml
@@ -19,8 +19,8 @@ keywords:
   - monitoring
 
 kubeVersion: ">= 1.29.0-0"
-version: v1.2.0
-appVersion: "v1.2.0"
+version: v1.2.1
+appVersion: "v1.2.1"
 
 dependencies:
 - name: nfd

--- a/helm-charts-openshift/crds/deviceconfig-crd.yaml
+++ b/helm-charts-openshift/crds/deviceconfig-crd.yaml
@@ -9,10 +9,10 @@ metadata:
   labels:
     app.kubernetes.io/component: amd-gpu
     app.kubernetes.io/part-of: amd-gpu
-    helm.sh/chart: gpu-operator-charts-v1.2.0
+    helm.sh/chart: gpu-operator-charts-v1.2.1
     app.kubernetes.io/name: gpu-operator-charts
     app.kubernetes.io/instance: amd-gpu
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   group: amd.com

--- a/helm-charts-openshift/values.yaml
+++ b/helm-charts-openshift/values.yaml
@@ -12,7 +12,7 @@ controllerManager:
       allowPrivilegeEscalation: false
     image:
       repository: docker.io/rocm/gpu-operator
-      tag: v1.2.0
+      tag: v1.2.1
     imagePullPolicy: Always
     imagePullSecrets: ""
     tolerations:

--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -19,8 +19,8 @@ keywords:
   - monitoring
 
 kubeVersion: ">= 1.29.0-0"
-version: v1.2.0
-appVersion: "v1.2.0"
+version: v1.2.1
+appVersion: "v1.2.1"
 
 dependencies:
 - name: node-feature-discovery

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -65,7 +65,7 @@ Basic installation:
 helm install amd-gpu-operator rocm/gpu-operator-charts \
   --namespace kube-amd-gpu \
   --create-namespace \
-  --version=v1.2.0
+  --version=v1.2.1
 ```
 
 ```{note}
@@ -101,7 +101,7 @@ The AMD GPU Operator is licensed under the [Apache License 2.0](LICENSE).
 
 ## gpu-operator-charts
 
-![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
+![Version: v1.2.1](https://img.shields.io/badge/Version-v1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.1](https://img.shields.io/badge/AppVersion-v1.2.1-informational?style=flat-square)
 
 AMD GPU Operator simplifies the deployment and management of AMD Instinct GPU accelerators within Kubernetes clusters.
 
@@ -132,7 +132,7 @@ Kubernetes: `>= 1.29.0-0`
 |-----|------|---------|-------------|
 | controllerManager.affinity | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]},"weight":1}]}}` | Deployment affinity configs for controller manager |
 | controllerManager.manager.image.repository | string | `"docker.io/rocm/gpu-operator"` | AMD GPU operator controller manager image repository |
-| controllerManager.manager.image.tag | string | `"v1.2.0"` | AMD GPU operator controller manager image tag |
+| controllerManager.manager.image.tag | string | `"v1.2.1"` | AMD GPU operator controller manager image tag |
 | controllerManager.manager.imagePullPolicy | string | `"Always"` | Image pull policy for AMD GPU operator controller manager pod |
 | controllerManager.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image |
 | controllerManager.nodeSelector | object | `{}` | Node selector for AMD GPU operator controller manager deployment |
@@ -145,12 +145,12 @@ Kubernetes: `>= 1.29.0-0`
 | kmm.controller.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | kmm.controller.manager.env.relatedImageBuild | string | `"gcr.io/kaniko-project/executor:v1.23.2"` | KMM kaniko builder image for building driver image within cluster |
 | kmm.controller.manager.env.relatedImageBuildPullSecret | string | `""` | Image pull secret name for pulling KMM kaniko builder image if registry needs credential to pull image |
-| kmm.controller.manager.env.relatedImageSign | string | `"docker.io/rocm/kernel-module-management-signimage:v1.2.0"` | KMM signer image for signing driver image's kernel module with given key pairs within cluster |
+| kmm.controller.manager.env.relatedImageSign | string | `"docker.io/rocm/kernel-module-management-signimage:v1.2.1"` | KMM signer image for signing driver image's kernel module with given key pairs within cluster |
 | kmm.controller.manager.env.relatedImageSignPullSecret | string | `""` | Image pull secret name for pulling KMM signer image if registry needs credential to pull image |
-| kmm.controller.manager.env.relatedImageWorker | string | `"docker.io/rocm/kernel-module-management-worker:v1.2.0"` | KMM worker image for loading / unloading driver kernel module on worker nodes |
+| kmm.controller.manager.env.relatedImageWorker | string | `"docker.io/rocm/kernel-module-management-worker:v1.2.1"` | KMM worker image for loading / unloading driver kernel module on worker nodes |
 | kmm.controller.manager.env.relatedImageWorkerPullSecret | string | `""` | Image pull secret name for pulling KMM worker image if registry needs credential to pull image |
 | kmm.controller.manager.image.repository | string | `"docker.io/rocm/kernel-module-management-operator"` | KMM controller manager image repository |
-| kmm.controller.manager.image.tag | string | `"v1.2.0"` | KMM controller manager image tag |
+| kmm.controller.manager.image.tag | string | `"v1.2.1"` | KMM controller manager image tag |
 | kmm.controller.manager.imagePullPolicy | string | `"Always"` | Image pull policy for KMM controller manager pod |
 | kmm.controller.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling KMM controller manager image if registry needs credential to pull image |
 | kmm.controller.manager.resources.limits.cpu | string | `"500m"` |  |
@@ -184,7 +184,7 @@ Kubernetes: `>= 1.29.0-0`
 | kmm.webhookServer.webhookServer.args[3] | string | `"--enable-preflightvalidation"` |  |
 | kmm.webhookServer.webhookServer.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | kmm.webhookServer.webhookServer.image.repository | string | `"docker.io/rocm/kernel-module-management-webhook-server"` | KMM webhook image repository |
-| kmm.webhookServer.webhookServer.image.tag | string | `"v1.2.0"` | KMM webhook image tag |
+| kmm.webhookServer.webhookServer.image.tag | string | `"v1.2.1"` | KMM webhook image tag |
 | kmm.webhookServer.webhookServer.imagePullPolicy | string | `"Always"` | Image pull policy for KMM webhook pod |
 | kmm.webhookServer.webhookServer.imagePullSecrets | string | `""` | Image pull secret name for pulling KMM webhook image if registry needs credential to pull image |
 | kmm.webhookServer.webhookServer.resources.limits.cpu | string | `"500m"` |  |

--- a/helm-charts/charts/kmm/values.yaml
+++ b/helm-charts/charts/kmm/values.yaml
@@ -8,9 +8,9 @@ controller:
       # -- KMM kaniko builder image for building driver image within cluster
       relatedImageBuild: gcr.io/kaniko-project/executor:v1.23.2
       # -- KMM signer image for signing driver image's kernel module with given key pairs within cluster
-      relatedImageSign: docker.io/rocm/kernel-module-management-signimage:v1.2.0
+      relatedImageSign: docker.io/rocm/kernel-module-management-signimage:v1.2.1
       # -- KMM worker image for loading / unloading driver kernel module on worker nodes
-      relatedImageWorker: docker.io/rocm/kernel-module-management-worker:v1.2.0
+      relatedImageWorker: docker.io/rocm/kernel-module-management-worker:v1.2.1
       # -- Image pull secret name for pulling KMM kaniko builder image if registry needs credential to pull image
       relatedImageBuildPullSecret: ""
       # -- Image pull secret name for pulling KMM signer image if registry needs credential to pull image
@@ -21,7 +21,7 @@ controller:
       # -- KMM controller manager image repository
       repository: docker.io/rocm/kernel-module-management-operator
       # -- KMM controller manager image tag
-      tag: v1.2.0
+      tag: v1.2.1
     # -- Image pull policy for KMM controller manager pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling KMM controller manager image if registry needs credential to pull image
@@ -104,7 +104,7 @@ webhookServer:
       # -- KMM webhook image repository
       repository: docker.io/rocm/kernel-module-management-webhook-server
       # -- KMM webhook image tag
-      tag: v1.2.0
+      tag: v1.2.1
     # -- Image pull policy for KMM webhook pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling KMM webhook image if registry needs credential to pull image

--- a/helm-charts/crds/deviceconfig-crd.yaml
+++ b/helm-charts/crds/deviceconfig-crd.yaml
@@ -9,10 +9,10 @@ metadata:
   labels:
     app.kubernetes.io/component: amd-gpu
     app.kubernetes.io/part-of: amd-gpu
-    helm.sh/chart: gpu-operator-charts-v1.2.0
+    helm.sh/chart: gpu-operator-charts-v1.2.1
     app.kubernetes.io/name: gpu-operator-charts
     app.kubernetes.io/instance: amd-gpu
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   group: amd.com

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -25,7 +25,7 @@ controllerManager:
       # -- AMD GPU operator controller manager image repository
       repository: docker.io/rocm/gpu-operator
       # -- AMD GPU operator controller manager image tag
-      tag: v1.2.0
+      tag: v1.2.1
     # -- Image pull policy for AMD GPU operator controller manager pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image

--- a/internal/metricsexporter/metricsexporter.go
+++ b/internal/metricsexporter/metricsexporter.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	defaultMetricsExporterImage       = "docker.io/rocm/device-metrics-exporter:v1.2.0"
+	defaultMetricsExporterImage       = "docker.io/rocm/device-metrics-exporter:v1.2.1"
 	defaultKubeRbacProxyImage         = "quay.io/brancz/kube-rbac-proxy:v0.18.1"
 	defaultInitContainerImage         = "busybox:1.36"
 	servicePort                 int32 = 5000

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	// TODO: determine where to host the test runner image and put the registry URL here
-	defaultTestRunnerImage       = "docker.io/rocm/test-runner:v1.2.0-beta.0"
+	defaultTestRunnerImage       = "docker.io/rocm/test-runner:v1.2.1-beta.0"
 	defaultInitContainerImage    = "busybox:1.36"
 	TestRunnerName               = "test-runner"
 	defaultSAName                = "amd-gpu-operator-test-runner"

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -5,10 +5,10 @@ endif
 E2E_INIT_CONTAINER_IMAGE ?= busybox:1.36
 E2E_KUBE_RBAC_PROXY_CURL_IMAGE ?= curlimages/curl:7.78.0
 E2E_UBUNTU_BASE_IMAGE ?= ubuntu:22.04
-E2E_EXPORTER_IMAGE ?= rocm/device-metrics-exporter:v1.2.0
+E2E_EXPORTER_IMAGE ?= rocm/device-metrics-exporter:v1.2.1
 E2E_DEVICE_PLUGIN_IMAGE ?= rocm/k8s-device-plugin:latest
 E2E_NODE_LABELLER_IMAGE ?= rocm/k8s-device-plugin:labeller-latest
-E2E_TEST_RUNNER_IMAGE ?= rocm/test-runner:v1.2.0-beta.0
+E2E_TEST_RUNNER_IMAGE ?= rocm/test-runner:v1.2.1-beta.0
 
 export E2E_INIT_CONTAINER_IMAGE
 export E2E_KUBE_RBAC_PROXY_CURL_IMAGE


### PR DESCRIPTION
Branch v1.2.1 is based out of v1.2.0. Hence we need to cherry-pick commits from v1.2.1 of internal GPU Operator repo as well and then add these changes on top.
Hence keeping the PR open. 
cc: @sajmera-pensando @yansun1996 @spraveenio 