### PR TITLE
Avoid cleanup all node labels under domain amd.com and beta.amd.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,8 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-UNIT_TEST ?= ./internal/controllers ./internal/kmmmodule
+UNIT_TEST ?= ./internal/controllers ./internal/kmmmodule ./internal
+
 .PHONY: unit-test
 unit-test: vet ## Run the unit tests.
 	go test $(UNIT_TEST) -v -coverprofile cover.out

--- a/internal/controllers/device_config_reconciler.go
+++ b/internal/controllers/device_config_reconciler.go
@@ -1159,12 +1159,11 @@ func (dcrh *deviceConfigReconcilerHelper) updateNodeLabels(ctx context.Context, 
 				}
 			}
 
-			for k := range nodeObjCopy.Labels {
-				if strings.HasPrefix(k, "beta.amd.com") ||
-					strings.HasPrefix(k, "amd.com") {
-					delete(nodeObj.Labels, k)
-					updated = true
-				}
+			// search for all existing node labeller labels and remove them
+			// NOTE: don't try to remove all labels with prefix amd.com and beta.amd.com
+			// users may want to self-define labels under amd.com domain like amd.com/gpu:true
+			if utils.RemoveOldNodeLabels(nodeObj) {
+				updated = true
 			}
 
 			// use PATCH instead of UPDATE

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -39,7 +39,79 @@ const (
 	ResourceNamingStrategyFlag = "resource_naming_strategy"
 	SingleStrategy             = "single"
 	MixedStrategy              = "mixed"
+	// node labeller
+	experimentalAMDPrefix             = "beta.amd.com"
+	amdPrefix                         = "amd.com"
+	computePartitioningSupportedLabel = "amd.com/compute-partitioning-supported"
+	memoryPartitioningSupportedLabel  = "amd.com/memory-partitioning-supported"
+	partitionTypeLabel                = "amd.com/compute-memory-partition"
 )
+
+var (
+	nodeLabellerKinds = []string{
+		"firmware", "family", "driver-version",
+		"driver-src-version", "device-id", "product-name",
+		"vram", "simd-count", "cu-count",
+	}
+	allAMDComLabels     = []string{}
+	allBetaAMDComLabels = []string{}
+)
+
+func init() {
+	initLabelLists()
+}
+
+func initLabelLists() {
+	// pre-generate all the available node labeller labels
+	// these 2 lists will be used to clean up old labels on the node
+	for _, name := range nodeLabellerKinds {
+		allAMDComLabels = append(allAMDComLabels, createLabelPrefix(name, false))
+		allBetaAMDComLabels = append(allBetaAMDComLabels, createLabelPrefix(name, true))
+	}
+	allAMDComLabels = append(allAMDComLabels,
+		computePartitioningSupportedLabel,
+		memoryPartitioningSupportedLabel,
+		partitionTypeLabel,
+	)
+}
+
+func createLabelPrefix(name string, experimental bool) string {
+	var prefix string
+	if experimental {
+		prefix = experimentalAMDPrefix
+	} else {
+		prefix = amdPrefix
+	}
+	return fmt.Sprintf("%s/gpu.%s", prefix, name)
+}
+
+func RemoveOldNodeLabels(node *v1.Node) bool {
+	updated := false
+	if node == nil {
+		return false
+	}
+	// for the amd.com node labels
+	// directly remove the old labels
+	for _, label := range allAMDComLabels {
+		if _, ok := node.Labels[label]; ok {
+			delete(node.Labels, label)
+			updated = true
+		}
+	}
+	// for the beta.amd.com node labels
+	// if it exists, both original label and counter label need to be removed, e.g.
+	// beta.amd.com/gpu.family: AI
+	// beta.amd.com/gpu.family.AI: "1"
+	for _, label := range allBetaAMDComLabels {
+		if val, ok := node.Labels[label]; ok {
+			delete(node.Labels, label)
+			counterLabel := fmt.Sprintf("%s.%s", label, val)
+			delete(node.Labels, counterLabel)
+			updated = true
+		}
+	}
+	return updated
+}
 
 func GetDriverVersion(node v1.Node, deviceConfig amdv1alpha1.DeviceConfig) (string, error) {
 	var driverVersion string

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	expectedAllLabelKeys = map[string]bool{
+		"amd.com/gpu.family":                     true,
+		"amd.com/gpu.driver-version":             true,
+		"amd.com/gpu.driver-src-version":         true,
+		"amd.com/gpu.firmware":                   true,
+		"amd.com/gpu.device-id":                  true,
+		"amd.com/gpu.product-name":               true,
+		"amd.com/gpu.vram":                       true,
+		"amd.com/gpu.simd-count":                 true,
+		"amd.com/gpu.cu-count":                   true,
+		"amd.com/compute-partitioning-supported": true,
+		"amd.com/memory-partitioning-supported":  true,
+		"amd.com/compute-memory-partition":       true,
+	}
+	expectedAllExperimentalLabelKeys = map[string]bool{
+		"beta.amd.com/gpu.family":             true,
+		"beta.amd.com/gpu.driver-version":     true,
+		"beta.amd.com/gpu.driver-src-version": true,
+		"beta.amd.com/gpu.firmware":           true,
+		"beta.amd.com/gpu.device-id":          true,
+		"beta.amd.com/gpu.product-name":       true,
+		"beta.amd.com/gpu.vram":               true,
+		"beta.amd.com/gpu.simd-count":         true,
+		"beta.amd.com/gpu.cu-count":           true,
+	}
+)
+
+func TestInitLabelLists(t *testing.T) {
+	labelMap := map[string]bool{}
+	for _, label := range allAMDComLabels {
+		labelMap[label] = true
+	}
+	if !reflect.DeepEqual(labelMap, expectedAllLabelKeys) {
+		t.Errorf("failed to get expected all labels during init, got %+v, expect %+v", labelMap, expectedAllLabelKeys)
+	}
+	experimentalLabelMap := map[string]bool{}
+	for _, label := range allBetaAMDComLabels {
+		experimentalLabelMap[label] = true
+	}
+	if !reflect.DeepEqual(experimentalLabelMap, expectedAllExperimentalLabelKeys) {
+		t.Errorf("failed to get expected all experimental labels during init, got %+v, expect %+v", labelMap, expectedAllLabelKeys)
+	}
+}
+
+func TestRemoveOldNodeLabels(t *testing.T) {
+	testCases := []struct {
+		inputNode     *v1.Node
+		expectLabels  map[string]string
+		expectUpdated bool
+	}{
+		{
+			inputNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"amd.com/gpu.cu-count":                          "104",
+						"amd.com/gpu.device-id":                         "740f",
+						"amd.com/gpu.driver-version":                    "6.10.5",
+						"amd.com/gpu.family":                            "AI",
+						"amd.com/gpu.product-name":                      "Instinct_MI210",
+						"amd.com/gpu.simd-count":                        "416",
+						"amd.com/gpu.vram":                              "64G",
+						"beta.amd.com/gpu.cu-count":                     "104",
+						"beta.amd.com/gpu.cu-count.104":                 "1",
+						"beta.amd.com/gpu.device-id":                    "740f",
+						"beta.amd.com/gpu.device-id.740f":               "1",
+						"beta.amd.com/gpu.family":                       "HPC",
+						"beta.amd.com/gpu.family.HPC":                   "1",
+						"beta.amd.com/gpu.product-name":                 "Instinct_MI300X",
+						"beta.amd.com/gpu.product-name.Instinct_MI300X": "1",
+						"beta.amd.com/gpu.simd-count":                   "416",
+						"beta.amd.com/gpu.simd-count.416":               "1",
+						"beta.amd.com/gpu.vram":                         "64G",
+						"beta.amd.com/gpu.vram.64G":                     "1",
+						"dummyLabel1":                                   "1",
+						"dummyLabel2":                                   "2",
+						// users may want to use label like this to integrate with their system
+						"amd.com/gpu": "true",
+					},
+				},
+			},
+			expectLabels: map[string]string{
+				"dummyLabel1": "1",
+				"dummyLabel2": "2",
+				"amd.com/gpu": "true",
+			},
+			expectUpdated: true,
+		},
+		{
+			inputNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						// users may want to use label like this to integrate with their system
+						"amd.com/gpu":                         "true",
+						"feature.node.kubernetes.io/amd-gpu":  "true",
+						"feature.node.kubernetes.io/amd-vgpu": "true",
+						"kubernetes.io/host-name":             "node",
+					},
+				},
+			},
+			expectLabels: map[string]string{
+				"amd.com/gpu":                         "true",
+				"feature.node.kubernetes.io/amd-gpu":  "true",
+				"feature.node.kubernetes.io/amd-vgpu": "true",
+				"kubernetes.io/host-name":             "node",
+			},
+			expectUpdated: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		updated := RemoveOldNodeLabels(tc.inputNode)
+		if !reflect.DeepEqual(tc.inputNode.Labels, tc.expectLabels) {
+			t.Errorf("failed to get expected node labels after removing old labels, got %+v, expect %+v", tc.inputNode.Labels, tc.expectLabels)
+		}
+		if updated != tc.expectUpdated {
+			t.Errorf("failed to get expected node labels updated flag, got %+v, expect %+v", updated, tc.expectUpdated)
+		}
+	}
+}


### PR DESCRIPTION
* fix: Only remove node labeller managed labels

The reconciler currently removes all labels with the amd.com and beta.amd.com prefix on nodes during cleanup. This is overly aggressive and can delete labels added by other users or systems.

This commit corrects the behavior to only remove labels that are specifically managed by node labeller, ensuring that only relevant labels are automatically cleaned up.

* test: Add more unit test cases for label cleanup modification

Fixing issue https://github.com/ROCm/gpu-operator/issues/151