### PR TITLE
Expose NFD worker nodeSelector and tolerations in main chart values.yaml

### DIFF
--- a/hack/k8s-patch/metadata-patch/values.yaml
+++ b/hack/k8s-patch/metadata-patch/values.yaml
@@ -1,13 +1,17 @@
 # NFD related configs
+# schema reference: https://github.com/kubernetes-sigs/node-feature-discovery/blob/release-0.16/deployment/helm/node-feature-discovery/values.yaml
 node-feature-discovery:
   # -- Set to true/false to enable/disable the installation of node feature discovery (NFD) operator
   enabled: true
   worker:
+    # -- Set tolerations for NFD worker daemonset
     tolerations:
       - key: "amd-dcm"
         operator: "Equal"
         value: "up"
         effect: "NoExecute"
+    # -- Set nodeSelector for NFD worker daemonset
+    nodeSelector: {}
 
 # KMM related configs
 kmm:

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:f9a315dd2ce3d515ebf28c8e9a6a82158b493ca2686439ec381487761261b597
-generated: "2025-04-21T19:12:52.553614798Z"
+generated: "2025-04-29T00:58:38.678746563Z"

--- a/helm-charts-k8s/README.md
+++ b/helm-charts-k8s/README.md
@@ -143,6 +143,8 @@ Kubernetes: `>= 1.29.0-0`
 | installdefaultNFDRule | bool | `true` | Default NFD rule will detect amd gpu based on pci vendor ID |
 | kmm.enabled | bool | `true` | Set to true/false to enable/disable the installation of kernel module management (KMM) operator |
 | node-feature-discovery.enabled | bool | `true` | Set to true/false to enable/disable the installation of node feature discovery (NFD) operator |
+| node-feature-discovery.worker.nodeSelector | object | `{}` | Set nodeSelector for NFD worker daemonset |
+| node-feature-discovery.worker.tolerations | list | `[{"effect":"NoExecute","key":"amd-dcm","operator":"Equal","value":"up"}]` | Set tolerations for NFD worker daemonset |
 | upgradeCRD | bool | `true` | CRD will be patched as pre-upgrade/pre-rollback hook when doing helm upgrade/rollback to current helm chart |
 | kmm.controller.affinity | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]},"weight":1}]}}` | Affinity for the KMM controller manager deployment |
 | kmm.controller.manager.args[0] | string | `"--config=controller_config.yaml"` |  |

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -1,13 +1,17 @@
 # NFD related configs
+# schema reference: https://github.com/kubernetes-sigs/node-feature-discovery/blob/release-0.16/deployment/helm/node-feature-discovery/values.yaml
 node-feature-discovery:
   # -- Set to true/false to enable/disable the installation of node feature discovery (NFD) operator
   enabled: true
   worker:
+    # -- Set tolerations for NFD worker daemonset
     tolerations:
       - key: "amd-dcm"
         operator: "Equal"
         value: "up"
         effect: "NoExecute"
+    # -- Set nodeSelector for NFD worker daemonset
+    nodeSelector: {}
 
 # KMM related configs
 kmm:


### PR DESCRIPTION
Expose NFD worker daemonset's nodeSelector and tolerations config into the ```values.yaml``` of main helm chart.

Related feature request https://github.com/ROCm/gpu-operator/issues/149