### PR TITLE
Expand default NFD rule to more GPU models based on ROCm support matrix

### DIFF
--- a/hack/k8s-patch/template-patch/nfd-default-rule.yaml
+++ b/hack/k8s-patch/template-patch/nfd-default-rule.yaml
@@ -6,12 +6,15 @@ metadata:
   # the PCI info is from these websites:
   # source1: https://admin.pci-ids.ucw.cz/read/PC/1002
   # source2: https://devicehunt.com/view/type/pci/vendor/1002
+  # Please refre to ROCm official website 
+  # vfor the driver compatibility matrix for different GPU models
 spec:
   rules:
   - name: amd-vgpu
     labels:
       feature.node.kubernetes.io/amd-vgpu: "true"
     matchAny:
+      # AMD Instinct
       - matchFeatures:
           - feature: pci.device
             matchExpressions:
@@ -27,10 +30,42 @@ spec:
             matchExpressions:
                 vendor: {op: In, value: ["1002"]}
                 device: {op: In, value: ["74b9"]} # Mi325X VF
+      # AMD Radeon Pro
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["7461"]} # Radeon Pro V710 MxGPU
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["73ae"]} # Radeon Pro V620 MxGPU
   - name: amd-gpu
     labels:
       feature.node.kubernetes.io/amd-gpu: "true"
     matchAny:
+      # AMD Instinct
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74a5"]} # MI325X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74a2"]} # MI308X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74b6"]} # MI308X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74a8"]} # MI308X HF
       - matchFeatures:
           - feature: pci.device
             matchExpressions:
@@ -41,6 +76,16 @@ spec:
             matchExpressions:
               vendor: {op: In, value: ["1002"]}
               device: {op: In, value: ["74a1"]} # MI300X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74a9"]} # MI300X HF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74bd"]} # MI300X HF
       - matchFeatures:
           - feature: pci.device
             matchExpressions:
@@ -66,4 +111,66 @@ spec:
             matchExpressions:
               vendor: {op: In, value: ["1002"]}
               device: {op: In, value: ["738e"]} # MI100
+      # AMD Radeon Pro
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["7460"]} # V710
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["7448"]} # W7900
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["744a"]} # W7900 Dual Slot
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["745e"]} # W7800
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73a2"]} # W6900X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73a3"]} # W6800 GL-XL
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73ab"]} # W6800X / W6800X Duo
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73a1"]} # V620
+      # AMD Radeon
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["7550"]} # RX 9070 / 9070 XT
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["744c"]} # RX 7900 XT / 7900 XTX / 7900 GRE / 7900M
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73af"]} # RX 6900 XT
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73bf"]} # RX 6800 / 6800 XT / 6900 XT
 {{- end }}

--- a/helm-charts-k8s/templates/nfd-default-rule.yaml
+++ b/helm-charts-k8s/templates/nfd-default-rule.yaml
@@ -6,12 +6,15 @@ metadata:
   # the PCI info is from these websites:
   # source1: https://admin.pci-ids.ucw.cz/read/PC/1002
   # source2: https://devicehunt.com/view/type/pci/vendor/1002
+  # Please refre to ROCm official website 
+  # vfor the driver compatibility matrix for different GPU models
 spec:
   rules:
   - name: amd-vgpu
     labels:
       feature.node.kubernetes.io/amd-vgpu: "true"
     matchAny:
+      # AMD Instinct
       - matchFeatures:
           - feature: pci.device
             matchExpressions:
@@ -27,10 +30,42 @@ spec:
             matchExpressions:
                 vendor: {op: In, value: ["1002"]}
                 device: {op: In, value: ["74b9"]} # Mi325X VF
+      # AMD Radeon Pro
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["7461"]} # Radeon Pro V710 MxGPU
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["73ae"]} # Radeon Pro V620 MxGPU
   - name: amd-gpu
     labels:
       feature.node.kubernetes.io/amd-gpu: "true"
     matchAny:
+      # AMD Instinct
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74a5"]} # MI325X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74a2"]} # MI308X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74b6"]} # MI308X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74a8"]} # MI308X HF
       - matchFeatures:
           - feature: pci.device
             matchExpressions:
@@ -41,6 +76,16 @@ spec:
             matchExpressions:
               vendor: {op: In, value: ["1002"]}
               device: {op: In, value: ["74a1"]} # MI300X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74a9"]} # MI300X HF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["74bd"]} # MI300X HF
       - matchFeatures:
           - feature: pci.device
             matchExpressions:
@@ -66,4 +111,66 @@ spec:
             matchExpressions:
               vendor: {op: In, value: ["1002"]}
               device: {op: In, value: ["738e"]} # MI100
+      # AMD Radeon Pro
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["7460"]} # V710
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["7448"]} # W7900
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["744a"]} # W7900 Dual Slot
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["745e"]} # W7800
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73a2"]} # W6900X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73a3"]} # W6800 GL-XL
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73ab"]} # W6800X / W6800X Duo
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73a1"]} # V620
+      # AMD Radeon
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["7550"]} # RX 9070 / 9070 XT
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["744c"]} # RX 7900 XT / 7900 XTX / 7900 GRE / 7900M
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73af"]} # RX 6900 XT
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["73bf"]} # RX 6800 / 6800 XT / 6900 XT
 {{- end }}


### PR DESCRIPTION
Related feature ask: #56 #152 #154