### PR TITLE
Fix helm chart pre-upgrade hook to support Argo deployment

### DIFF
--- a/hack/k8s-patch/template-patch/pre-upgrade-hook.yaml
+++ b/hack/k8s-patch/template-patch/pre-upgrade-hook.yaml
@@ -1,3 +1,56 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pre-upgrade-check-sa
+  annotations:
+    # hook will be executed before helm upgrade
+    "helm.sh/hook": pre-upgrade,pre-rollback
+    # don't cleanup the job on hook failure
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
+    # hook with lower weight value will run firstly
+    "helm.sh/hook-weight": "0"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pre-upgrade-check-cluster-role
+  annotations:
+    # hook will be executed before helm upgrade
+    "helm.sh/hook": pre-upgrade,pre-rollback
+    # don't cleanup the job on hook failure
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
+    # hook with lower weight value will run firstly
+    "helm.sh/hook-weight": "0"
+rules:
+  - apiGroups:
+      - amd.com
+    resources:
+      - deviceconfigs
+    verbs:
+      - list
+      - get
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pre-upgrade-check-cluster-role-binding
+  annotations:
+    # hook will be executed before helm upgrade
+    "helm.sh/hook": pre-upgrade,pre-rollback
+    # don't cleanup the job on hook failure
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
+    # hook with lower weight value will run firstly
+    "helm.sh/hook-weight": "1"
+subjects:
+  - kind: ServiceAccount
+    name: pre-upgrade-check-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: pre-upgrade-check-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -11,13 +64,13 @@ metadata:
     # don't cleanup the job on hook failure
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
     # hook with lower weight value will run firstly
-    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-weight": "2"
 spec:
   backoffLimit: 0 # once the job finished first run, don't retry to create another pod
   ttlSecondsAfterFinished: 60 # job info will be kept for 1 min then deleted
   template:
     spec:
-      serviceAccountName: {{ include "helm-charts-k8s.fullname" . }}-controller-manager
+      serviceAccountName: pre-upgrade-check-sa
       containers:
         - name: pre-upgrade-check
           image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag }}
@@ -25,6 +78,14 @@ spec:
             - /bin/sh
             - -c
             - |
+              # Ignore the lack of CRDs, probably haven't actually been installed yet
+              # this provides idempotentcy when "things" don't userstand the difference between
+              # install and upgrade. E.g. Argo turns pre-upgrade hook into its PreSync hook
+              installed=$(kubectl api-resources -owide | grep -i amd.com | grep -i deviceconfig)
+              if [ -z ${installed} ] ; then
+                exit 0
+              fi
+
               # List all DeviceConfig CRs
               deviceconfigs=$(kubectl get deviceconfigs -n {{ .Release.Namespace }} -o json)
 

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:f9a315dd2ce3d515ebf28c8e9a6a82158b493ca2686439ec381487761261b597
-generated: "2025-04-30T04:45:58.172372146Z"
+generated: "2025-05-04T02:28:56.201802096Z"

--- a/helm-charts-k8s/templates/pre-upgrade-hook.yaml
+++ b/helm-charts-k8s/templates/pre-upgrade-hook.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: pre-upgrade-hook
+  name: pre-upgrade-check-sa
   annotations:
     # hook will be executed before helm upgrade
     "helm.sh/hook": pre-upgrade,pre-rollback
@@ -14,7 +14,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pre-upgrade-hook
+  name: pre-upgrade-check-cluster-role
   annotations:
     # hook will be executed before helm upgrade
     "helm.sh/hook": pre-upgrade,pre-rollback
@@ -29,11 +29,12 @@ rules:
       - deviceconfigs
     verbs:
       - list
+      - get
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: pre-upgrade-hook
+  name: pre-upgrade-check-cluster-role-binding
   annotations:
     # hook will be executed before helm upgrade
     "helm.sh/hook": pre-upgrade,pre-rollback
@@ -43,11 +44,11 @@ metadata:
     "helm.sh/hook-weight": "1"
 subjects:
   - kind: ServiceAccount
-    name: pre-upgrade-hook
+    name: pre-upgrade-check-sa
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: pre-upgrade-hook
+  name: pre-upgrade-check-cluster-role
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: batch/v1
@@ -69,7 +70,7 @@ spec:
   ttlSecondsAfterFinished: 60 # job info will be kept for 1 min then deleted
   template:
     spec:
-      serviceAccountName: pre-upgrade-hook
+      serviceAccountName: pre-upgrade-check-sa
       containers:
         - name: pre-upgrade-check
           image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag }}
@@ -77,11 +78,10 @@ spec:
             - /bin/sh
             - -c
             - |
-              # Ignore the lack of CRDs, we probably haven't actually been installed yet
+              # Ignore the lack of CRDs, probably haven't actually been installed yet
               # this provides idempotentcy when "things" don't userstand the difference between
-              # install and upgrade.
-              installed=$(kubectl api-resources | grep deviceconfigs)
-
+              # install and upgrade. E.g. Argo turns pre-upgrade hook into its PreSync hook
+              installed=$(kubectl api-resources -owide | grep -i amd.com | grep -i deviceconfig)
               if [ -z ${installed} ] ; then
                 exit 0
               fi

--- a/helm-charts-k8s/templates/pre-upgrade-hook.yaml
+++ b/helm-charts-k8s/templates/pre-upgrade-hook.yaml
@@ -1,3 +1,55 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pre-upgrade-hook
+  annotations:
+    # hook will be executed before helm upgrade
+    "helm.sh/hook": pre-upgrade,pre-rollback
+    # don't cleanup the job on hook failure
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
+    # hook with lower weight value will run firstly
+    "helm.sh/hook-weight": "0"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pre-upgrade-hook
+  annotations:
+    # hook will be executed before helm upgrade
+    "helm.sh/hook": pre-upgrade,pre-rollback
+    # don't cleanup the job on hook failure
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
+    # hook with lower weight value will run firstly
+    "helm.sh/hook-weight": "0"
+rules:
+  - apiGroups:
+      - amd.com
+    resources:
+      - deviceconfigs
+    verbs:
+      - list
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pre-upgrade-hook
+  annotations:
+    # hook will be executed before helm upgrade
+    "helm.sh/hook": pre-upgrade,pre-rollback
+    # don't cleanup the job on hook failure
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
+    # hook with lower weight value will run firstly
+    "helm.sh/hook-weight": "1"
+subjects:
+  - kind: ServiceAccount
+    name: pre-upgrade-hook
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: pre-upgrade-hook
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -11,13 +63,13 @@ metadata:
     # don't cleanup the job on hook failure
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded
     # hook with lower weight value will run firstly
-    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-weight": "2"
 spec:
   backoffLimit: 0 # once the job finished first run, don't retry to create another pod
   ttlSecondsAfterFinished: 60 # job info will be kept for 1 min then deleted
   template:
     spec:
-      serviceAccountName: {{ include "helm-charts-k8s.fullname" . }}-controller-manager
+      serviceAccountName: pre-upgrade-hook
       containers:
         - name: pre-upgrade-check
           image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag }}
@@ -25,6 +77,15 @@ spec:
             - /bin/sh
             - -c
             - |
+              # Ignore the lack of CRDs, we probably haven't actually been installed yet
+              # this provides idempotentcy when "things" don't userstand the difference between
+              # install and upgrade.
+              installed=$(kubectl api-resources | grep deviceconfigs)
+
+              if [ -z ${installed} ] ; then
+                exit 0
+              fi
+
               # List all DeviceConfig CRs
               deviceconfigs=$(kubectl get deviceconfigs -n {{ .Release.Namespace }} -o json)
 


### PR DESCRIPTION
Cherry-pick the idea came from an external PR https://github.com/ROCm/gpu-operator/pull/94 

1. Currently the ```pre-upgrade-check``` hook is replying on the Chart template defined service account, which is not going to work for Argo deployment, the ```pre-upgrade-check``` hook needs to define and use its own RBAC configs instead of replying on main chart RBAC settings, so that the hook could decouple with main chart resources.

2. Argo turns the helm pre-upgrade hook into pre-sync hook https://argo-cd.readthedocs.io/en/release-2.0/user-guide/helm/#helm-hooks , which means even the pre-upgrade are treated as the same as pre-install hook and getting executed when CRD were not even installed, we can ignore the NotFound CRD in the pre-upgrade hook and this won't affect the normal Helm Upgrade process.