### PR TITLE
upgrade param change during driver upgrade corner case

### DIFF
--- a/internal/controllers/upgrademgr.go
+++ b/internal/controllers/upgrademgr.go
@@ -141,6 +141,7 @@ func (n *upgradeMgr) HandleUpgrade(ctx context.Context, deviceConfig *amdv1alpha
 						}
 					}
 				} else {
+					go n.helper.deleteRebootPod(ctx, nodeName, *deviceConfig, true)
 					log.FromContext(ctx).Info(fmt.Sprintf("Node: %v: Resetting Upgrade State to UpgradeStateEmpty", nodeName))
 					n.helper.setNodeStatus(ctx, nodeName, amdv1alpha1.UpgradeStateEmpty)
 				}


### PR DESCRIPTION
Upgrade Policy parameter change takes effect on remaining nodes without being stuck for already ongoing nodes since we have now let reboot goroutines continue as expected for ongoing upgrade attempts based on driver version instead of genID in previous PR: https://github.com/ROCm/gpu-operator/pull/173

Handling one edge case scenario in this PR:
If operator goes down exactly when the CR update happens and rebootRequired is change from true to false in the CR update, then we need to delete the rebootpod as well.