### PR TITLE
Add default DeviceConfig into Helm Chart with e2e test and docs change

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,20 @@ helm install amd-gpu-operator rocm/gpu-operator-charts \
 > It is strongly recommended to use AMD-optimized KMM images included in the operator release. This is not required when installing the GPU Operator on Red Hat OpenShift.
 
 ### 3. Install Custom Resource
+After the installation of AMD GPU Operator:
+  * By default there will be a default `DeviceConfig` installed. If you are using default `DeviceConfig`, you can modify the default `DeviceConfig` to adjust the config for your own use case. `kubectl edit deviceconfigs -n kube-amd-gpu default`
+  * If you installed without default `DeviceConfig` (either by using `--set crds.defaultCR.install=false` or installing a chart prior to v1.3.0), you need to create the `DeviceConfig` custom resource in order to trigger the operator start to work. By preparing the `DeviceConfig` in the YAML file, you can create the resouce by running ```kubectl apply -f deviceconfigs.yaml```.
+  * For custom resource definition and more detailed information, please refer to [Custom Resource Installation Guide](https://dcgpu.docs.amd.com/projects/gpu-operator/en/latest/installation/kubernetes-helm.html#install-custom-resource).
 
-After the installation of AMD GPU Operator, you need to create the `DeviceConfig` custom resource in order to trigger the operator to start to work. By preparing the `DeviceConfig` in the YAML file, you can create the resouce by running ```kubectl apply -f deviceconfigs.yaml```. For custom resource definition and more detailed information, please refer to [Custom Resource Installation Guide](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/kubernetes-helm.html#install-custom-resource).
+  * Potential Failures with default `DeviceConfig`: 
+
+    a. Operand pods are stuck in ```Init:0/1``` state: It means your GPU worker doesn't have inbox GPU driver loaded. We suggest check the [Driver Installation Guide]([./drivers/installation.md](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/drivers/installation.html#driver-installation-guide)) then modify the default `DeviceConfig` to ask Operator to install the out-of-tree GPU driver for your worker nodes.
+  `kubectl edit deviceconfigs -n kube-amd-gpu default`
+
+    b. No operand pods showed up: It is possible that default `DeviceConfig` selector `feature.node.kubernetes.io/amd-gpu: "true"` cannot find any matched node.
+      * Check node label `kubectl get node -oyaml | grep -e "amd-gpu:" -e "amd-vgpu:"`
+      * If you are using GPU in the VM, you may need to change the default `DeviceConfig` selector to `feature.node.kubernetes.io/amd-vgpu: "true"`
+      * You can always customize the node selector of the `DeviceConfig`.
 
 ### Grafana Dashboards
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ external_projects = ["amd-gpu-operator"]
 external_projects_current_project = "amd-gpu-operator"
 
 project = "AMD GPU Operator"
-version = "1.2.1"
+version = "1.3.0"
 release = version
 html_title = f"{project} {version}"
 author = "Advanced Micro Devices, Inc."

--- a/docs/installation/kubernetes-helm.md
+++ b/docs/installation/kubernetes-helm.md
@@ -132,10 +132,12 @@ helm install amd-gpu-operator amd/gpu-operator-helm \
 ```
 ````
 
-You can also specify the following installation Options to disable NFD or KMM, although this is not recommended unless you know what you are doing:
-
-- Skip NFD installation: `--set node-feature-discovery.enabled=false`
-- Skip KMM installation: `--set kmm.enabled=false`
+```{note}
+Installation Options
+  - Skip NFD installation: `--set node-feature-discovery.enabled=false`
+  - Skip KMM installation: `--set kmm.enabled=false`
+  - Disable default DeviceConfig installation: `--set crds.defaultCR.install=false`
+```
 
 ```{warning}
   It is strongly recommended to use AMD-optimized KMM images included in the operator release.
@@ -293,6 +295,7 @@ You can apply resource changes by updating your values.yaml file and upgrading t
 
 ```bash
 helm upgrade amd-gpu-operator amd/gpu-operator-helm \
+  --debug \
   --namespace kube-amd-gpu \
   --version=v1.0.0 \
   -f values.yaml
@@ -300,7 +303,10 @@ helm upgrade amd-gpu-operator amd/gpu-operator-helm \
 
 ## Install Custom Resource
 
-After the installation of AMD GPU Operator, you need to create the `DeviceConfig` custom resource in order to trigger the operator start to work. By preparing the `DeviceConfig` in the YAML file, you can create the resouce by running ```kubectl apply -f deviceconfigs.yaml```. For custom resource definition and more detailed information, please refer to [Custom Resource Installation Guide](../drivers/installation). Here are some examples for common deployment scenarios.
+After the installation of AMD GPU Operator:
+  * If you are using default `DeviceConfig`, you can modify the default `DeviceConfig` to adjust the config for your own use case. `kubectl edit deviceconfigs -n kube-amd-gpu default`
+  * If you installed without default `DeviceConfig` (either by using `--set crds.defaultCR.install=false` or installing a chart prior to v1.3.0), you need to create the `DeviceConfig` custom resource in order to trigger the operator start to work. By preparing the `DeviceConfig` in the YAML file, you can create the resouce by running ```kubectl apply -f deviceconfigs.yaml```.
+  * For custom resource definition and more detailed information, please refer to [Custom Resource Installation Guide](../drivers/installation). Here are some examples for common deployment scenarios.
 
 ### Inbox or Pre-Installed AMD GPU Drivers
 

--- a/docs/sphinx/_toc.yml
+++ b/docs/sphinx/_toc.yml
@@ -45,6 +45,7 @@ subtrees:
       - file: test/manual-test
       - file: test/pre-start-job-test
       - file: test/appendix-test-recipe
+      - file: test/logs-export
   - caption: Device Plugin
     entries:
       - file: device_plugin/device-plugin

--- a/docs/uninstallation/uninstallation.md
+++ b/docs/uninstallation/uninstallation.md
@@ -29,10 +29,10 @@ or refer to [Troubleshooting](../troubleshooting) document to find the solution.
 ## Uninstall Helm Charts
 
 ```bash
-helm uninstall amd-gpu-operator -n kube-amd-gpu
+helm uninstall amd-gpu-operator -n kube-amd-gpu --debug
 ```
 
-By default the helm uninstall command will call a pre-delete hook to check if there is any `DeviceConfig` custom resources existing in the cluster. If you forget to remove all the `DeviceConfig` custom resources, the pre-delete hook will stop the helm uninstall process. In that situation, please delete all existing `DeviceConfig`.
+By default the helm uninstall command will call a pre-delete hook to delete all the existing `DeviceConfig` in the cluster for all namespaces.
 
 ```{note}
 The pre-delete hook is using the operator controller image to run kubectl for checking existing `DeviceConfig`, if you want to skip the pre-delete hook, you can run helm uninstall command with ```--no-hooks``` option, in that way the Helm Charts will be immediately uninstalled but may have risk that some `DeviceConfig` resources still remain in the cluster.
@@ -40,7 +40,7 @@ The pre-delete hook is using the operator controller image to run kubectl for ch
 
 ## Uninstall Custom Resource Definition
 
-By default Helm Charts won't uninstall the CRDs for users, so you may need to manually clean up CRDs after uninstalling the Helm Charts. To list all existing CRDs, run this command:
+By default Helm Charts are using a post-delete hook to uninstall the CRDs for users. If the Helm Charts uninstallation was running with ```--no-hooks``` you may need to manually clean up CRDs after uninstalling the Helm Charts. To list all existing CRDs, run this command:
 
 ```bash
 $ kubectl get crds

--- a/hack/k8s-patch/metadata-patch/values.yaml
+++ b/hack/k8s-patch/metadata-patch/values.yaml
@@ -24,6 +24,207 @@ installdefaultNFDRule: true
 # -- CRD will be patched as pre-upgrade/pre-rollback hook when doing helm upgrade/rollback to current helm chart
 upgradeCRD: true
 
+crds:
+  defaultCR:
+    # -- Deploy default DeviceConfig during helm chart installation
+    install: true
+    # -- Deploy / Patch default DeviceConfig during helm chart upgrade. Be careful about this option: 1. Your customized change on default DeviceConfig may be overwritten 2. Your existing DeviceConfig may conflict with upgraded default DeviceConfig 
+    upgrade: false
+
+deviceConfig:
+  spec:
+    # -- Set node selector for the default DeviceConfig
+    selector:
+      feature.node.kubernetes.io/amd-gpu: "true"
+    driver:
+      # -- enable/disable out-of-tree driver management, set to false to use inbox driver
+      enable: false
+      # -- enable/disable putting a blacklist amdgpu entry in modprobe config, which requires node labeller to run
+      blacklist: false
+      # -- image repository to store out-of-tree driver image, DO NOT put image tag since operator automatically manage it for users
+      image: "docker.io/myUserName/driverImage"
+      # -- image pull secret for pull/push access of the driver image repository, input secret name like {"name": "mysecret"}
+      imageRegistrySecret: {}
+      imageRegistryTLS:
+        # -- set to true to use plain HTTP for driver image repository
+        insecure: false
+        # -- set to true to skip TLS validation for driver image repository
+        insecureSkipTLSVerify: false
+      # -- specify an out-of-tree driver version to install
+      version: "6.4"
+      # -- specify the secrets to sign the out-of-tree kernel module inside driver image for secure boot, e.g. input private / public key secret {"keySecret":{"name":"privateKeySecret"},"certSecret":{"name":"publicKeySecret"}}
+      imageSign: {}
+      upgradePolicy:
+        # -- enable/disable automatic driver upgrade feature 
+        enable: true
+        # -- how many nodes can be upgraded in parallel
+        maxParallelUpgrades: 3
+        # -- maximum number of nodes that can be in a failed upgrade state beyond which upgrades will stop to keep cluster at a minimal healthy state
+        maxUnavailableNodes: 25%
+        # -- whether reboot each worker node or not during the driver upgrade
+        rebootRequired: true
+        nodeDrainPolicy:
+          # -- whether force draining is allowed or not
+          force: true
+          # -- the length of time in seconds to wait before giving up drain, zero means infinite
+          timeoutSeconds: 300
+          # -- the time kubernetes waits for a pod to shut down gracefully after receiving a termination signal, zero means immediate, minus value means follow pod defined grace period
+          gracePeriodSeconds: -1
+        podDeletionPolicy:
+          # -- whether force deletion is allowed or not
+          force: true
+          # -- the length of time in seconds to wait before giving up on pod deletion, zero means infinite
+          timeoutSeconds: 300
+          # -- the time kubernetes waits for a pod to shut down gracefully after receiving a termination signal, zero means immediate, minus value means follow pod defined grace period
+          gracePeriodSeconds: -1
+    commonConfig:
+      # -- init container image
+      initContainerImage: busybox:1.36
+      utilsContainer:
+        # -- gpu operator utility container image
+        image: docker.io/rocm/gpu-operator-utils:v1.2.1
+        # -- utility container image pull policy
+        imagePullPolicy: IfNotPresent
+        # -- utility container image pull secret, e.g. {"name": "mySecretName"}
+        imageRegistrySecret: {}
+    devicePlugin:
+      # -- device plugin image
+      devicePluginImage: rocm/k8s-device-plugin:latest
+      # -- device plugin image pull policy
+      devicePluginImagePullPolicy: IfNotPresent
+      # -- device plugin tolerations
+      devicePluginTolerations: []
+      # -- pass supported flags and their values while starting device plugin daemonset, e.g. {"resource_naming_strategy": "single"} or {"resource_naming_strategy": "mixed"}
+      devicePluginArguments: {}
+      # -- enable / disable node labeller
+      enableNodeLabeller: true
+      # -- node labeller image
+      nodeLabellerImage: rocm/k8s-device-plugin:labeller-latest
+      # -- node labeller image pull policy
+      nodeLabellerImagePullPolicy: IfNotPresent
+      # -- node labeller tolerations
+      nodeLabellerTolerations: []
+      # -- pass supported labels while starting node labeller daemonset, default ["vram", "cu-count", "simd-count", "device-id", "family", "product-name", "driver-version"], also support ["compute-memory-partition", "compute-partitioning-supported", "memory-partitioning-supported"]
+      nodeLabellerArguments: []
+      # -- image pull secret for device plugin and node labeller, e.g. {"name": "mySecretName"}
+      imageRegistrySecret: {}
+      upgradePolicy:
+        # -- the type of daemonset upgrade, RollingUpdate or OnDelete
+        upgradeStrategy: RollingUpdate
+        # -- the maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 1
+    metricsExporter:
+      # -- enable / disable device metrics exporter
+      enable: true
+      # -- type of service for exposing metrics endpoint, ClusterIP or NodePort
+      serviceType: ClusterIP
+      # -- internal port used for in-cluster and node access to pull metrics from the metrics-exporter (default 5000).
+      port: 5000
+      # -- external port for pulling metrics from outside the cluster for NodePort service, in the range 30000-32767 (assigned automatically by default)
+      nodePort: 32500
+      # -- metrics exporter image
+      image: rocm/device-metrics-exporter:v1.3.0
+      # -- metrics exporter image pull policy
+      imagePullPolicy: "IfNotPresent"
+      # -- name of the metrics exporter config map, e.g. {"name": "metricConfigMapName"}
+      config: {}
+      # -- metrics exporter tolerations
+      tolerations: []
+      # -- metrics exporter image pull secret, e.g. {"name": "pullSecretName"}
+      imageRegistrySecret: {}
+      # -- metrics exporter node selector, if not specified it will reuse spec.selector
+      selector: {}
+      upgradePolicy:
+        # -- the type of daemonset upgrade, RollingUpdate or OnDelete
+        upgradeStrategy: RollingUpdate
+        # -- the maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 1
+      rbacConfig:
+        # -- enable/disable kube rbac proxy
+        enable: false
+        # -- kube rbac proxy side car container image
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.1
+        # -- disable https protecting the proxy endpoint
+        disableHttps: false
+        # -- certificate secret to mount in kube-rbac container for TLS, self signed certificates will be generated by default, e.g. {"name": "secretName"}
+        secret: {}
+        # -- reference to a configmap containing the client CA (key: ca.crt) for mTLS client validation, e.g. {"name": "configMapName"}
+        clientCAConfigMap: {}
+        staticAuthorization:
+          # -- enables static authorization using client certificate CN
+          enable: false
+          # -- expected CN (Common Name) from client cert (e.g., Prometheus SA identity)
+          clientName: ""
+      prometheus:
+        serviceMonitor:
+          # -- enable or disable ServiceMonitor creation
+          enable: false
+          # -- frequency to scrape metrics. Accepts values with time unit suffix: "30s", "1m", "2h", "500ms"
+          interval: 30s
+          # -- define if Prometheus should attach node metadata to the target, e.g. {"node": "true"}
+          attachMetadata: {}
+          # -- choose the metric's labels on collisions with target labels
+          honorLabels: true
+          # -- control whether the scrape endpoints honor timestamps
+          honorTimestamps: false
+          # -- additional labels to add to the ServiceMonitor
+          labels: {}
+          # -- relabelConfigs to apply to samples before ingestion
+          relabelings: []
+          # -- relabeling rules applied to individual scraped metrics
+          metricRelabelings: []
+          # -- optional Prometheus authorization configuration for accessing the endpoint
+          authorization: {}
+          # -- TLS settings used by Prometheus to connect to the metrics endpoint
+          tlsConfig: {}
+    testRunner:
+      # -- enable / disable test runner
+      enable: false
+      # -- test runner image
+      image: docker.io/rocm/test-runner:v1.3.0
+      # -- test runner image pull policy
+      imagePullPolicy: "IfNotPresent" 
+      # -- test runner config map, e.g. {"name": "myConfigMap"}
+      config: {}
+      logsLocation:
+        # -- test runner internal mounted directory to save test run logs
+        mountPath: "/var/log/amd-test-runner" 
+        # -- host directory to save test run logs
+        hostPath: "/var/log/amd-test-runner"
+        # -- a list of secrets that contain connectivity info to multiple cloud providers
+        logsExportSecrets: []
+      upgradePolicy:
+        # -- the type of daemonset upgrade, RollingUpdate or OnDelete
+        upgradeStrategy: RollingUpdate
+        # -- the maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 1
+      # -- test runner tolerations
+      tolerations: []
+      # -- test runner image pull secret
+      imageRegistrySecret: {}
+      # -- test runner node selector, if not specified it will reuse spec.selector
+      selector: {}
+    configManager:
+      # -- enable/disable the config manager 
+      enable: false
+      # -- config manager image
+      image: rocm/device-config-manager:v1.3.0
+      # -- image pull policy for config manager image
+      imagePullPolicy: IfNotPresent
+      # -- image pull secret for config manager image, e.g. {"name": "myPullSecret"}
+      imageRegistrySecret: {}
+      # -- config map for config manager, e.g. {"name": "myConfigMap"}
+      config: {}
+      # -- node selector for config manager, if not specified it will reuse spec.selector
+      selector: {}
+      upgradePolicy:
+        # -- the type of daemonset upgrade, RollingUpdate or OnDelete
+        upgradeStrategy: RollingUpdate
+        # -- the maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 1
+      # -- config manager tolerations
+      configManagerTolerations: []
+
 # AMD GPU operator controller related configs
 controllerManager:
   manager:

--- a/hack/k8s-patch/template-patch/default-deviceconfig.yaml
+++ b/hack/k8s-patch/template-patch/default-deviceconfig.yaml
@@ -1,0 +1,353 @@
+
+{{- if or (and .Release.IsInstall .Values.crds.defaultCR.install) (and .Release.IsUpgrade .Values.crds.defaultCR.upgrade) }}
+{{- if and (hasKey .Values "deviceConfig") (hasKey .Values.deviceConfig "spec") }}
+apiVersion: amd.com/v1alpha1
+kind: DeviceConfig
+metadata:
+  name: default
+  # the default CR cleanup is handled by pre-delete hook
+  # add this annotation so that helm won't try to delete the default DeviceConfig twice
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  {{- with .Values.deviceConfig.spec.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.driver }}
+  driver:
+    {{- if (hasKey . "enable") }}
+    enable: {{ .enable }}
+    {{- end }}
+
+    {{- if (hasKey . "blacklist") }}
+    blacklist: {{ .blacklist }}
+    {{- end }}
+
+    {{- with .image }}
+    image: {{ . }}
+    {{- end }}
+
+    {{- with .imageRegistrySecret }}
+    imageRegistrySecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .imageRegistryTLS }}
+    imageRegistryTLS:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .version }}
+    version: {{ quote . }}
+    {{- end }}
+
+    {{- with .imageSign }}
+    imageSign:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .upgradePolicy }}
+    upgradePolicy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.commonConfig }}
+  commonConfig:
+    {{- with .initContainerImage }}
+    initContainerImage: {{ . }}
+    {{- end }}
+
+    {{- with .utilsContainer }}
+    utilsContainer:
+      {{- with .image }}
+      image: {{ . }}
+      {{- end }}
+
+      {{- with .imagePullPolicy }}
+      imagePullPolicy: {{ . }}
+      {{- end }}
+
+      {{- with .imageRegistrySecret }}
+      imageRegistrySecret:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.devicePlugin }}
+  devicePlugin:
+    {{- with .devicePluginImage }}
+    devicePluginImage: {{ . }}
+    {{- end }}
+
+    {{- with .devicePluginImagePullPolicy }}
+    devicePluginImagePullPolicy: {{ . }}
+    {{- end }}
+
+    {{- with .devicePluginTolerations }}
+    devicePluginTolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .devicePluginArguments }}
+    devicePluginArguments:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- if (hasKey . "enableNodeLabeller") }}
+    enableNodeLabeller: {{ .enableNodeLabeller }}
+    {{- end }}
+
+    {{- with .nodeLabellerImage }}
+    nodeLabellerImage: {{ . }}
+    {{- end }}
+
+    {{- with .nodeLabellerImagePullPolicy }}
+    nodeLabellerImagePullPolicy: {{ . }}
+    {{- end }}
+
+    {{- with .nodeLabellerTolerations }}
+    nodeLabellerTolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .nodeLabellerArguments }}
+    nodeLabellerArguments:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .imageRegistrySecret }}
+    imageRegistrySecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .upgradePolicy }}
+    upgradePolicy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.metricsExporter }}
+  metricsExporter:
+    {{- if (hasKey . "enable") }}
+    enable: {{ .enable }}
+    {{- end }}
+
+    {{- with .serviceType }}
+    serviceType: {{ . }}
+    {{- end }}
+
+    {{- if (hasKey . "port") }}
+    port: {{ .port }}
+    {{- end }}
+
+    {{- if (hasKey . "nodePort") }}
+    nodePort: {{ .nodePort }}
+    {{- end }}
+
+    {{- with .image }}
+    image: {{ . }}
+    {{- end }}
+
+    {{- with .imagePullPolicy }}
+    imagePullPolicy: {{ . }}
+    {{- end }}
+
+    {{- with .config }}
+    config:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .imageRegistrySecret }}
+    imageRegistrySecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .selector }}
+    selector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .upgradePolicy }}
+    upgradePolicy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .rbacConfig }}
+    rbacConfig:
+      {{- if (hasKey . "enable") }}
+      enable: {{ .enable }}
+      {{- end }}
+
+      {{- with .image }}
+      image: {{ . }}
+      {{- end }}
+
+      {{- if (hasKey . "disableHttps")}}
+      disableHttps: {{ .disableHttps }}
+      {{- end }}
+
+      {{- with .secret }}
+      secret:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .clientCAConfigMap }}
+      clientCAConfigMap:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .staticAuthorization }}
+      staticAuthorization:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+
+    {{- with .prometheus }}
+    prometheus:
+      {{- with .serviceMonitor }}
+      serviceMonitor:
+        {{- if (hasKey . "enable") }}
+        enable: {{ .enable }}
+        {{- end }}
+
+        {{- if (hasKey . "interval") }}
+        interval: {{ .interval }}
+        {{- end }}
+
+        {{- with .attachMetadata }}
+        attachMetadata:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- if (hasKey . "honorLabels") }}
+        honorLabels: {{ .honorLabels }}
+        {{- end }}
+
+        {{- if (hasKey . "honorTimestamps") }}
+        honorTimestamps: {{ .honorTimestamps }}
+        {{- end }}
+
+        {{- with .labels }}
+        labels:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- with .relabelings }}
+        relabelings:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- with .metricRelabelings }}
+        metricRelabelings:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- with .authorization }}
+        authorization:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- with .tlsConfig }}
+        tlsConfig:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.testRunner }}
+  testRunner:
+    {{- if (hasKey . "enable") }}
+    enable: {{ .enable }}
+    {{- end }}
+
+    {{- with .image }}
+    image: {{ . }}
+    {{- end }}
+
+    {{- with .imagePullPolicy }}
+    imagePullPolicy: {{ . }}
+    {{- end }}
+
+    {{- with .config }}
+    config:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .logsLocation }}
+    logsLocation:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .upgradePolicy }}
+    upgradePolicy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .imageRegistrySecret }}
+    imageRegistrySecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .selector }}
+    selector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.configManager }}
+  configManager:
+    {{- if (hasKey . "enable") }}
+    enable: {{ .enable }}
+    {{- end }}
+
+    {{- with .image }}
+    image: {{ . }}
+    {{- end }}
+
+    {{- with .imagePullPolicy }}
+    imagePullPolicy: {{ . }}
+    {{- end }}
+
+    {{- with .imageRegistrySecret }}
+    imageRegistrySecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .config }}
+    config:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .selector }}
+    selector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .upgradePolicy }}
+    upgradePolicy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .configManagerTolerations }}
+    configManagerTolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+{{- end }}
+{{- end }}

--- a/hack/k8s-patch/template-patch/pre-delete-hook.yaml
+++ b/hack/k8s-patch/template-patch/pre-delete-hook.yaml
@@ -31,6 +31,7 @@ rules:
     verbs:
       - get
       - list
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -55,7 +56,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: check-leftover-deviceconfigs
+  name: delete-leftover-deviceconfigs
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "helm-charts-k8s.labels" . | nindent 4 }}
@@ -73,19 +74,18 @@ spec:
     spec:
       serviceAccountName: {{ include "helm-charts-k8s.fullname" . }}-pre-delete
       containers:
-        - name: check-leftover-deviceconfigs
+        - name: delete-leftover-deviceconfigs
           image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag }}
           command:
             - /bin/sh
             - -c
             - |
-              if kubectl get deviceconfigs -n {{ .Release.Namespace }} --no-headers | grep -q .; then
-                echo "DeviceConfigs resources exist. Stop uninstallation."
-                exit 1
-              else
-                echo "No DeviceConfigs resources found. Proceeding with uninstallation."
+              installed=$(kubectl api-resources -owide | grep -i amd.com | grep -i deviceconfig)
+              if [ -z ${installed} ] ; then
                 exit 0
               fi
+              # Delete all existing DeviceConfig custom resources
+              kubectl delete deviceconfigs.amd.com --all -A
       {{- if .Values.controllerManager.manager.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.controllerManager.manager.imagePullSecrets }}

--- a/hack/k8s-patch/template-patch/pre-upgrade-hook.yaml
+++ b/hack/k8s-patch/template-patch/pre-upgrade-hook.yaml
@@ -79,7 +79,7 @@ spec:
             - -c
             - |
               # Ignore the lack of CRDs, probably haven't actually been installed yet
-              # this provides idempotentcy when "things" don't userstand the difference between
+              # this provides idempotentcy when "things" don't understand the difference between
               # install and upgrade. E.g. Argo turns pre-upgrade hook into its PreSync hook
               installed=$(kubectl api-resources -owide | grep -i amd.com | grep -i deviceconfig)
               if [ -z ${installed} ] ; then

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:f9a315dd2ce3d515ebf28c8e9a6a82158b493ca2686439ec381487761261b597
-generated: "2025-05-08T06:33:22.365680047Z"
+generated: "2025-05-14T21:06:12.36965018Z"

--- a/helm-charts-k8s/README.md
+++ b/helm-charts-k8s/README.md
@@ -140,6 +140,93 @@ Kubernetes: `>= 1.29.0-0`
 | controllerManager.manager.imagePullPolicy | string | `"Always"` | Image pull policy for AMD GPU operator controller manager pod |
 | controllerManager.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image |
 | controllerManager.nodeSelector | object | `{}` | Node selector for AMD GPU operator controller manager deployment |
+| crds.defaultCR.install | bool | `true` | Deploy default DeviceConfig during helm chart installation |
+| crds.defaultCR.upgrade | bool | `false` | Deploy / Patch default DeviceConfig during helm chart upgrade. Be careful about this option: 1. Your customized change on default DeviceConfig may be overwritten 2. Your existing DeviceConfig may conflict with upgraded default DeviceConfig  |
+| deviceConfig.spec.commonConfig.initContainerImage | string | `"busybox:1.36"` | init container image |
+| deviceConfig.spec.commonConfig.utilsContainer.image | string | `"docker.io/rocm/gpu-operator-utils:v1.2.1"` | gpu operator utility container image |
+| deviceConfig.spec.commonConfig.utilsContainer.imagePullPolicy | string | `"IfNotPresent"` | utility container image pull policy |
+| deviceConfig.spec.commonConfig.utilsContainer.imageRegistrySecret | object | `{}` | utility container image pull secret, e.g. {"name": "mySecretName"} |
+| deviceConfig.spec.configManager.config | object | `{}` | config map for config manager, e.g. {"name": "myConfigMap"} |
+| deviceConfig.spec.configManager.configManagerTolerations | list | `[]` | config manager tolerations |
+| deviceConfig.spec.configManager.enable | bool | `false` | enable/disable the config manager  |
+| deviceConfig.spec.configManager.image | string | `"rocm/device-config-manager:v1.3.0"` | config manager image |
+| deviceConfig.spec.configManager.imagePullPolicy | string | `"IfNotPresent"` | image pull policy for config manager image |
+| deviceConfig.spec.configManager.imageRegistrySecret | object | `{}` | image pull secret for config manager image, e.g. {"name": "myPullSecret"} |
+| deviceConfig.spec.configManager.selector | object | `{}` | node selector for config manager, if not specified it will reuse spec.selector |
+| deviceConfig.spec.configManager.upgradePolicy.maxUnavailable | int | `1` | the maximum number of Pods that can be unavailable during the update process |
+| deviceConfig.spec.configManager.upgradePolicy.upgradeStrategy | string | `"RollingUpdate"` | the type of daemonset upgrade, RollingUpdate or OnDelete |
+| deviceConfig.spec.devicePlugin.devicePluginArguments | object | `{}` | pass supported flags and their values while starting device plugin daemonset, e.g. {"resource_naming_strategy": "single"} or {"resource_naming_strategy": "mixed"} |
+| deviceConfig.spec.devicePlugin.devicePluginImage | string | `"rocm/k8s-device-plugin:latest"` | device plugin image |
+| deviceConfig.spec.devicePlugin.devicePluginImagePullPolicy | string | `"IfNotPresent"` | device plugin image pull policy |
+| deviceConfig.spec.devicePlugin.devicePluginTolerations | list | `[]` | device plugin tolerations |
+| deviceConfig.spec.devicePlugin.enableNodeLabeller | bool | `true` | enable / disable node labeller |
+| deviceConfig.spec.devicePlugin.imageRegistrySecret | object | `{}` | image pull secret for device plugin and node labeller, e.g. {"name": "mySecretName"} |
+| deviceConfig.spec.devicePlugin.nodeLabellerArguments | list | `[]` | pass supported labels while starting node labeller daemonset, default ["vram", "cu-count", "simd-count", "device-id", "family", "product-name", "driver-version"], also support ["compute-memory-partition", "compute-partitioning-supported", "memory-partitioning-supported"] |
+| deviceConfig.spec.devicePlugin.nodeLabellerImage | string | `"rocm/k8s-device-plugin:labeller-latest"` | node labeller image |
+| deviceConfig.spec.devicePlugin.nodeLabellerImagePullPolicy | string | `"IfNotPresent"` | node labeller image pull policy |
+| deviceConfig.spec.devicePlugin.nodeLabellerTolerations | list | `[]` | node labeller tolerations |
+| deviceConfig.spec.devicePlugin.upgradePolicy.maxUnavailable | int | `1` | the maximum number of Pods that can be unavailable during the update process |
+| deviceConfig.spec.devicePlugin.upgradePolicy.upgradeStrategy | string | `"RollingUpdate"` | the type of daemonset upgrade, RollingUpdate or OnDelete |
+| deviceConfig.spec.driver.blacklist | bool | `false` | enable/disable putting a blacklist amdgpu entry in modprobe config, which requires node labeller to run |
+| deviceConfig.spec.driver.enable | bool | `false` | enable/disable out-of-tree driver management, set to false to use inbox driver |
+| deviceConfig.spec.driver.image | string | `"docker.io/myUserName/driverImage"` | image repository to store out-of-tree driver image, DO NOT put image tag since operator automatically manage it for users |
+| deviceConfig.spec.driver.imageRegistrySecret | object | `{}` | image pull secret for pull/push access of the driver image repository, input secret name like {"name": "mysecret"} |
+| deviceConfig.spec.driver.imageRegistryTLS.insecure | bool | `false` | set to true to use plain HTTP for driver image repository |
+| deviceConfig.spec.driver.imageRegistryTLS.insecureSkipTLSVerify | bool | `false` | set to true to skip TLS validation for driver image repository |
+| deviceConfig.spec.driver.imageSign | object | `{}` | specify the secrets to sign the out-of-tree kernel module inside driver image for secure boot, e.g. input private / public key secret {"keySecret":{"name":"privateKeySecret"},"certSecret":{"name":"publicKeySecret"}} |
+| deviceConfig.spec.driver.upgradePolicy.enable | bool | `true` | enable/disable automatic driver upgrade feature  |
+| deviceConfig.spec.driver.upgradePolicy.maxParallelUpgrades | int | `3` | how many nodes can be upgraded in parallel |
+| deviceConfig.spec.driver.upgradePolicy.maxUnavailableNodes | string | `"25%"` | maximum number of nodes that can be in a failed upgrade state beyond which upgrades will stop to keep cluster at a minimal healthy state |
+| deviceConfig.spec.driver.upgradePolicy.nodeDrainPolicy.force | bool | `true` | whether force draining is allowed or not |
+| deviceConfig.spec.driver.upgradePolicy.nodeDrainPolicy.gracePeriodSeconds | int | `-1` | the time kubernetes waits for a pod to shut down gracefully after receiving a termination signal, zero means immediate, minus value means follow pod defined grace period |
+| deviceConfig.spec.driver.upgradePolicy.nodeDrainPolicy.timeoutSeconds | int | `300` | the length of time in seconds to wait before giving up drain, zero means infinite |
+| deviceConfig.spec.driver.upgradePolicy.podDeletionPolicy.force | bool | `true` | whether force deletion is allowed or not |
+| deviceConfig.spec.driver.upgradePolicy.podDeletionPolicy.gracePeriodSeconds | int | `-1` | the time kubernetes waits for a pod to shut down gracefully after receiving a termination signal, zero means immediate, minus value means follow pod defined grace period |
+| deviceConfig.spec.driver.upgradePolicy.podDeletionPolicy.timeoutSeconds | int | `300` | the length of time in seconds to wait before giving up on pod deletion, zero means infinite |
+| deviceConfig.spec.driver.upgradePolicy.rebootRequired | bool | `true` | whether reboot each worker node or not during the driver upgrade |
+| deviceConfig.spec.driver.version | string | `"6.4"` | specify an out-of-tree driver version to install |
+| deviceConfig.spec.metricsExporter.config | object | `{}` | name of the metrics exporter config map, e.g. {"name": "metricConfigMapName"} |
+| deviceConfig.spec.metricsExporter.enable | bool | `true` | enable / disable device metrics exporter |
+| deviceConfig.spec.metricsExporter.image | string | `"rocm/device-metrics-exporter:v1.3.0"` | metrics exporter image |
+| deviceConfig.spec.metricsExporter.imagePullPolicy | string | `"IfNotPresent"` | metrics exporter image pull policy |
+| deviceConfig.spec.metricsExporter.imageRegistrySecret | object | `{}` | metrics exporter image pull secret, e.g. {"name": "pullSecretName"} |
+| deviceConfig.spec.metricsExporter.nodePort | int | `32500` | external port for pulling metrics from outside the cluster for NodePort service, in the range 30000-32767 (assigned automatically by default) |
+| deviceConfig.spec.metricsExporter.port | int | `5000` | internal port used for in-cluster and node access to pull metrics from the metrics-exporter (default 5000). |
+| deviceConfig.spec.metricsExporter.prometheus.serviceMonitor.attachMetadata | object | `{}` | define if Prometheus should attach node metadata to the target, e.g. {"node": "true"} |
+| deviceConfig.spec.metricsExporter.prometheus.serviceMonitor.authorization | object | `{}` | optional Prometheus authorization configuration for accessing the endpoint |
+| deviceConfig.spec.metricsExporter.prometheus.serviceMonitor.enable | bool | `false` | enable or disable ServiceMonitor creation |
+| deviceConfig.spec.metricsExporter.prometheus.serviceMonitor.honorLabels | bool | `true` | choose the metric's labels on collisions with target labels |
+| deviceConfig.spec.metricsExporter.prometheus.serviceMonitor.honorTimestamps | bool | `false` | control whether the scrape endpoints honor timestamps |
+| deviceConfig.spec.metricsExporter.prometheus.serviceMonitor.interval | string | `"30s"` | frequency to scrape metrics. Accepts values with time unit suffix: "30s", "1m", "2h", "500ms" |
+| deviceConfig.spec.metricsExporter.prometheus.serviceMonitor.labels | object | `{}` | additional labels to add to the ServiceMonitor |
+| deviceConfig.spec.metricsExporter.prometheus.serviceMonitor.metricRelabelings | list | `[]` | relabeling rules applied to individual scraped metrics |
+| deviceConfig.spec.metricsExporter.prometheus.serviceMonitor.relabelings | list | `[]` | relabelConfigs to apply to samples before ingestion |
+| deviceConfig.spec.metricsExporter.prometheus.serviceMonitor.tlsConfig | object | `{}` | TLS settings used by Prometheus to connect to the metrics endpoint |
+| deviceConfig.spec.metricsExporter.rbacConfig.clientCAConfigMap | object | `{}` | reference to a configmap containing the client CA (key: ca.crt) for mTLS client validation, e.g. {"name": "configMapName"} |
+| deviceConfig.spec.metricsExporter.rbacConfig.disableHttps | bool | `false` | disable https protecting the proxy endpoint |
+| deviceConfig.spec.metricsExporter.rbacConfig.enable | bool | `false` | enable/disable kube rbac proxy |
+| deviceConfig.spec.metricsExporter.rbacConfig.image | string | `"quay.io/brancz/kube-rbac-proxy:v0.18.1"` | kube rbac proxy side car container image |
+| deviceConfig.spec.metricsExporter.rbacConfig.secret | object | `{}` | certificate secret to mount in kube-rbac container for TLS, self signed certificates will be generated by default, e.g. {"name": "secretName"} |
+| deviceConfig.spec.metricsExporter.rbacConfig.staticAuthorization.clientName | string | `""` | expected CN (Common Name) from client cert (e.g., Prometheus SA identity) |
+| deviceConfig.spec.metricsExporter.rbacConfig.staticAuthorization.enable | bool | `false` | enables static authorization using client certificate CN |
+| deviceConfig.spec.metricsExporter.selector | object | `{}` | metrics exporter node selector, if not specified it will reuse spec.selector |
+| deviceConfig.spec.metricsExporter.serviceType | string | `"ClusterIP"` | type of service for exposing metrics endpoint, ClusterIP or NodePort |
+| deviceConfig.spec.metricsExporter.tolerations | list | `[]` | metrics exporter tolerations |
+| deviceConfig.spec.metricsExporter.upgradePolicy.maxUnavailable | int | `1` | the maximum number of Pods that can be unavailable during the update process |
+| deviceConfig.spec.metricsExporter.upgradePolicy.upgradeStrategy | string | `"RollingUpdate"` | the type of daemonset upgrade, RollingUpdate or OnDelete |
+| deviceConfig.spec.selector | object | `{"feature.node.kubernetes.io/amd-gpu":"true"}` | Set node selector for the default DeviceConfig |
+| deviceConfig.spec.testRunner.config | object | `{}` | test runner config map, e.g. {"name": "myConfigMap"} |
+| deviceConfig.spec.testRunner.enable | bool | `false` | enable / disable test runner |
+| deviceConfig.spec.testRunner.image | string | `"docker.io/rocm/test-runner:v1.3.0"` | test runner image |
+| deviceConfig.spec.testRunner.imagePullPolicy | string | `"IfNotPresent"` | test runner image pull policy |
+| deviceConfig.spec.testRunner.imageRegistrySecret | object | `{}` | test runner image pull secret |
+| deviceConfig.spec.testRunner.logsLocation.hostPath | string | `"/var/log/amd-test-runner"` | host directory to save test run logs |
+| deviceConfig.spec.testRunner.logsLocation.logsExportSecrets | list | `[]` | a list of secrets that contain connectivity info to multiple cloud providers |
+| deviceConfig.spec.testRunner.logsLocation.mountPath | string | `"/var/log/amd-test-runner"` | test runner internal mounted directory to save test run logs |
+| deviceConfig.spec.testRunner.selector | object | `{}` | test runner node selector, if not specified it will reuse spec.selector |
+| deviceConfig.spec.testRunner.tolerations | list | `[]` | test runner tolerations |
+| deviceConfig.spec.testRunner.upgradePolicy.maxUnavailable | int | `1` | the maximum number of Pods that can be unavailable during the update process |
+| deviceConfig.spec.testRunner.upgradePolicy.upgradeStrategy | string | `"RollingUpdate"` | the type of daemonset upgrade, RollingUpdate or OnDelete |
 | installdefaultNFDRule | bool | `true` | Default NFD rule will detect amd gpu based on pci vendor ID |
 | kmm.enabled | bool | `true` | Set to true/false to enable/disable the installation of kernel module management (KMM) operator |
 | node-feature-discovery.enabled | bool | `true` | Set to true/false to enable/disable the installation of node feature discovery (NFD) operator |

--- a/helm-charts-k8s/README.md
+++ b/helm-charts-k8s/README.md
@@ -79,8 +79,20 @@ helm install amd-gpu-operator rocm/gpu-operator-charts \
 > It is strongly recommended to use AMD-optimized KMM images included in the operator release. This is not required when installing the GPU Operator on Red Hat OpenShift.
 
 ### 3. Install Custom Resource
+After the installation of AMD GPU Operator:
+  * By default there will be a default `DeviceConfig` installed. If you are using default `DeviceConfig`, you can modify the default `DeviceConfig` to adjust the config for your own use case. `kubectl edit deviceconfigs -n kube-amd-gpu default`
+  * If you installed without default `DeviceConfig` (either by using `--set crds.defaultCR.install=false` or installing a chart prior to v1.3.0), you need to create the `DeviceConfig` custom resource in order to trigger the operator start to work. By preparing the `DeviceConfig` in the YAML file, you can create the resouce by running ```kubectl apply -f deviceconfigs.yaml```.
+  * For custom resource definition and more detailed information, please refer to [Custom Resource Installation Guide](https://dcgpu.docs.amd.com/projects/gpu-operator/en/latest/installation/kubernetes-helm.html#install-custom-resource).
 
-After the installation of AMD GPU Operator, you need to create the `DeviceConfig` custom resource in order to trigger the operator to start to work. By preparing the `DeviceConfig` in the YAML file, you can create the resouce by running ```kubectl apply -f deviceconfigs.yaml```. For custom resource definition and more detailed information, please refer to [Custom Resource Installation Guide](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/kubernetes-helm.html#install-custom-resource).
+  * Potential Failures with default `DeviceConfig`: 
+
+    a. Operand pods are stuck in ```Init:0/1``` state: It means your GPU worker doesn't have inbox GPU driver loaded. We suggest check the [Driver Installation Guide]([./drivers/installation.md](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/drivers/installation.html#driver-installation-guide)) then modify the default `DeviceConfig` to ask Operator to install the out-of-tree GPU driver for your worker nodes.
+  `kubectl edit deviceconfigs -n kube-amd-gpu default`
+
+    b. No operand pods showed up: It is possible that default `DeviceConfig` selector `feature.node.kubernetes.io/amd-gpu: "true"` cannot find any matched node.
+      * Check node label `kubectl get node -oyaml | grep -e "amd-gpu:" -e "amd-vgpu:"`
+      * If you are using GPU in the VM, you may need to change the default `DeviceConfig` selector to `feature.node.kubernetes.io/amd-vgpu: "true"`
+      * You can always customize the node selector of the `DeviceConfig`.
 
 ### Grafana Dashboards
 

--- a/helm-charts-k8s/templates/default-deviceconfig.yaml
+++ b/helm-charts-k8s/templates/default-deviceconfig.yaml
@@ -1,0 +1,353 @@
+
+{{- if or (and .Release.IsInstall .Values.crds.defaultCR.install) (and .Release.IsUpgrade .Values.crds.defaultCR.upgrade) }}
+{{- if and (hasKey .Values "deviceConfig") (hasKey .Values.deviceConfig "spec") }}
+apiVersion: amd.com/v1alpha1
+kind: DeviceConfig
+metadata:
+  name: default
+  # the default CR cleanup is handled by pre-delete hook
+  # add this annotation so that helm won't try to delete the default DeviceConfig twice
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  {{- with .Values.deviceConfig.spec.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.driver }}
+  driver:
+    {{- if (hasKey . "enable") }}
+    enable: {{ .enable }}
+    {{- end }}
+
+    {{- if (hasKey . "blacklist") }}
+    blacklist: {{ .blacklist }}
+    {{- end }}
+
+    {{- with .image }}
+    image: {{ . }}
+    {{- end }}
+
+    {{- with .imageRegistrySecret }}
+    imageRegistrySecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .imageRegistryTLS }}
+    imageRegistryTLS:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .version }}
+    version: {{ quote . }}
+    {{- end }}
+
+    {{- with .imageSign }}
+    imageSign:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .upgradePolicy }}
+    upgradePolicy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.commonConfig }}
+  commonConfig:
+    {{- with .initContainerImage }}
+    initContainerImage: {{ . }}
+    {{- end }}
+
+    {{- with .utilsContainer }}
+    utilsContainer:
+      {{- with .image }}
+      image: {{ . }}
+      {{- end }}
+
+      {{- with .imagePullPolicy }}
+      imagePullPolicy: {{ . }}
+      {{- end }}
+
+      {{- with .imageRegistrySecret }}
+      imageRegistrySecret:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.devicePlugin }}
+  devicePlugin:
+    {{- with .devicePluginImage }}
+    devicePluginImage: {{ . }}
+    {{- end }}
+
+    {{- with .devicePluginImagePullPolicy }}
+    devicePluginImagePullPolicy: {{ . }}
+    {{- end }}
+
+    {{- with .devicePluginTolerations }}
+    devicePluginTolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .devicePluginArguments }}
+    devicePluginArguments:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- if (hasKey . "enableNodeLabeller") }}
+    enableNodeLabeller: {{ .enableNodeLabeller }}
+    {{- end }}
+
+    {{- with .nodeLabellerImage }}
+    nodeLabellerImage: {{ . }}
+    {{- end }}
+
+    {{- with .nodeLabellerImagePullPolicy }}
+    nodeLabellerImagePullPolicy: {{ . }}
+    {{- end }}
+
+    {{- with .nodeLabellerTolerations }}
+    nodeLabellerTolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .nodeLabellerArguments }}
+    nodeLabellerArguments:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .imageRegistrySecret }}
+    imageRegistrySecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .upgradePolicy }}
+    upgradePolicy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.metricsExporter }}
+  metricsExporter:
+    {{- if (hasKey . "enable") }}
+    enable: {{ .enable }}
+    {{- end }}
+
+    {{- with .serviceType }}
+    serviceType: {{ . }}
+    {{- end }}
+
+    {{- if (hasKey . "port") }}
+    port: {{ .port }}
+    {{- end }}
+
+    {{- if (hasKey . "nodePort") }}
+    nodePort: {{ .nodePort }}
+    {{- end }}
+
+    {{- with .image }}
+    image: {{ . }}
+    {{- end }}
+
+    {{- with .imagePullPolicy }}
+    imagePullPolicy: {{ . }}
+    {{- end }}
+
+    {{- with .config }}
+    config:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .imageRegistrySecret }}
+    imageRegistrySecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .selector }}
+    selector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .upgradePolicy }}
+    upgradePolicy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .rbacConfig }}
+    rbacConfig:
+      {{- if (hasKey . "enable") }}
+      enable: {{ .enable }}
+      {{- end }}
+
+      {{- with .image }}
+      image: {{ . }}
+      {{- end }}
+
+      {{- if (hasKey . "disableHttps")}}
+      disableHttps: {{ .disableHttps }}
+      {{- end }}
+
+      {{- with .secret }}
+      secret:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .clientCAConfigMap }}
+      clientCAConfigMap:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .staticAuthorization }}
+      staticAuthorization:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+
+    {{- with .prometheus }}
+    prometheus:
+      {{- with .serviceMonitor }}
+      serviceMonitor:
+        {{- if (hasKey . "enable") }}
+        enable: {{ .enable }}
+        {{- end }}
+
+        {{- if (hasKey . "interval") }}
+        interval: {{ .interval }}
+        {{- end }}
+
+        {{- with .attachMetadata }}
+        attachMetadata:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- if (hasKey . "honorLabels") }}
+        honorLabels: {{ .honorLabels }}
+        {{- end }}
+
+        {{- if (hasKey . "honorTimestamps") }}
+        honorTimestamps: {{ .honorTimestamps }}
+        {{- end }}
+
+        {{- with .labels }}
+        labels:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- with .relabelings }}
+        relabelings:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- with .metricRelabelings }}
+        metricRelabelings:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- with .authorization }}
+        authorization:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        {{- with .tlsConfig }}
+        tlsConfig:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.testRunner }}
+  testRunner:
+    {{- if (hasKey . "enable") }}
+    enable: {{ .enable }}
+    {{- end }}
+
+    {{- with .image }}
+    image: {{ . }}
+    {{- end }}
+
+    {{- with .imagePullPolicy }}
+    imagePullPolicy: {{ . }}
+    {{- end }}
+
+    {{- with .config }}
+    config:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .logsLocation }}
+    logsLocation:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .upgradePolicy }}
+    upgradePolicy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .imageRegistrySecret }}
+    imageRegistrySecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .selector }}
+    selector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- with .Values.deviceConfig.spec.configManager }}
+  configManager:
+    {{- if (hasKey . "enable") }}
+    enable: {{ .enable }}
+    {{- end }}
+
+    {{- with .image }}
+    image: {{ . }}
+    {{- end }}
+
+    {{- with .imagePullPolicy }}
+    imagePullPolicy: {{ . }}
+    {{- end }}
+
+    {{- with .imageRegistrySecret }}
+    imageRegistrySecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .config }}
+    config:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .selector }}
+    selector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .upgradePolicy }}
+    upgradePolicy:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- with .configManagerTolerations }}
+    configManagerTolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+{{- end }}
+{{- end }}

--- a/helm-charts-k8s/templates/pre-delete-hook.yaml
+++ b/helm-charts-k8s/templates/pre-delete-hook.yaml
@@ -31,6 +31,7 @@ rules:
     verbs:
       - get
       - list
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -55,7 +56,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: check-leftover-deviceconfigs
+  name: delete-leftover-deviceconfigs
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "helm-charts-k8s.labels" . | nindent 4 }}
@@ -73,19 +74,18 @@ spec:
     spec:
       serviceAccountName: {{ include "helm-charts-k8s.fullname" . }}-pre-delete
       containers:
-        - name: check-leftover-deviceconfigs
+        - name: delete-leftover-deviceconfigs
           image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag }}
           command:
             - /bin/sh
             - -c
             - |
-              if kubectl get deviceconfigs -n {{ .Release.Namespace }} --no-headers | grep -q .; then
-                echo "DeviceConfigs resources exist. Stop uninstallation."
-                exit 1
-              else
-                echo "No DeviceConfigs resources found. Proceeding with uninstallation."
+              installed=$(kubectl api-resources -owide | grep -i amd.com | grep -i deviceconfig)
+              if [ -z ${installed} ] ; then
                 exit 0
               fi
+              # Delete all existing DeviceConfig custom resources
+              kubectl delete deviceconfigs.amd.com --all -A
       {{- if .Values.controllerManager.manager.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.controllerManager.manager.imagePullSecrets }}

--- a/helm-charts-k8s/templates/pre-upgrade-hook.yaml
+++ b/helm-charts-k8s/templates/pre-upgrade-hook.yaml
@@ -79,7 +79,7 @@ spec:
             - -c
             - |
               # Ignore the lack of CRDs, probably haven't actually been installed yet
-              # this provides idempotentcy when "things" don't userstand the difference between
+              # this provides idempotentcy when "things" don't understand the difference between
               # install and upgrade. E.g. Argo turns pre-upgrade hook into its PreSync hook
               installed=$(kubectl api-resources -owide | grep -i amd.com | grep -i deviceconfig)
               if [ -z ${installed} ] ; then

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -24,6 +24,207 @@ installdefaultNFDRule: true
 # -- CRD will be patched as pre-upgrade/pre-rollback hook when doing helm upgrade/rollback to current helm chart
 upgradeCRD: true
 
+crds:
+  defaultCR:
+    # -- Deploy default DeviceConfig during helm chart installation
+    install: true
+    # -- Deploy / Patch default DeviceConfig during helm chart upgrade. Be careful about this option: 1. Your customized change on default DeviceConfig may be overwritten 2. Your existing DeviceConfig may conflict with upgraded default DeviceConfig 
+    upgrade: false
+
+deviceConfig:
+  spec:
+    # -- Set node selector for the default DeviceConfig
+    selector:
+      feature.node.kubernetes.io/amd-gpu: "true"
+    driver:
+      # -- enable/disable out-of-tree driver management, set to false to use inbox driver
+      enable: false
+      # -- enable/disable putting a blacklist amdgpu entry in modprobe config, which requires node labeller to run
+      blacklist: false
+      # -- image repository to store out-of-tree driver image, DO NOT put image tag since operator automatically manage it for users
+      image: "docker.io/myUserName/driverImage"
+      # -- image pull secret for pull/push access of the driver image repository, input secret name like {"name": "mysecret"}
+      imageRegistrySecret: {}
+      imageRegistryTLS:
+        # -- set to true to use plain HTTP for driver image repository
+        insecure: false
+        # -- set to true to skip TLS validation for driver image repository
+        insecureSkipTLSVerify: false
+      # -- specify an out-of-tree driver version to install
+      version: "6.4"
+      # -- specify the secrets to sign the out-of-tree kernel module inside driver image for secure boot, e.g. input private / public key secret {"keySecret":{"name":"privateKeySecret"},"certSecret":{"name":"publicKeySecret"}}
+      imageSign: {}
+      upgradePolicy:
+        # -- enable/disable automatic driver upgrade feature 
+        enable: true
+        # -- how many nodes can be upgraded in parallel
+        maxParallelUpgrades: 3
+        # -- maximum number of nodes that can be in a failed upgrade state beyond which upgrades will stop to keep cluster at a minimal healthy state
+        maxUnavailableNodes: 25%
+        # -- whether reboot each worker node or not during the driver upgrade
+        rebootRequired: true
+        nodeDrainPolicy:
+          # -- whether force draining is allowed or not
+          force: true
+          # -- the length of time in seconds to wait before giving up drain, zero means infinite
+          timeoutSeconds: 300
+          # -- the time kubernetes waits for a pod to shut down gracefully after receiving a termination signal, zero means immediate, minus value means follow pod defined grace period
+          gracePeriodSeconds: -1
+        podDeletionPolicy:
+          # -- whether force deletion is allowed or not
+          force: true
+          # -- the length of time in seconds to wait before giving up on pod deletion, zero means infinite
+          timeoutSeconds: 300
+          # -- the time kubernetes waits for a pod to shut down gracefully after receiving a termination signal, zero means immediate, minus value means follow pod defined grace period
+          gracePeriodSeconds: -1
+    commonConfig:
+      # -- init container image
+      initContainerImage: busybox:1.36
+      utilsContainer:
+        # -- gpu operator utility container image
+        image: docker.io/rocm/gpu-operator-utils:v1.2.1
+        # -- utility container image pull policy
+        imagePullPolicy: IfNotPresent
+        # -- utility container image pull secret, e.g. {"name": "mySecretName"}
+        imageRegistrySecret: {}
+    devicePlugin:
+      # -- device plugin image
+      devicePluginImage: rocm/k8s-device-plugin:latest
+      # -- device plugin image pull policy
+      devicePluginImagePullPolicy: IfNotPresent
+      # -- device plugin tolerations
+      devicePluginTolerations: []
+      # -- pass supported flags and their values while starting device plugin daemonset, e.g. {"resource_naming_strategy": "single"} or {"resource_naming_strategy": "mixed"}
+      devicePluginArguments: {}
+      # -- enable / disable node labeller
+      enableNodeLabeller: true
+      # -- node labeller image
+      nodeLabellerImage: rocm/k8s-device-plugin:labeller-latest
+      # -- node labeller image pull policy
+      nodeLabellerImagePullPolicy: IfNotPresent
+      # -- node labeller tolerations
+      nodeLabellerTolerations: []
+      # -- pass supported labels while starting node labeller daemonset, default ["vram", "cu-count", "simd-count", "device-id", "family", "product-name", "driver-version"], also support ["compute-memory-partition", "compute-partitioning-supported", "memory-partitioning-supported"]
+      nodeLabellerArguments: []
+      # -- image pull secret for device plugin and node labeller, e.g. {"name": "mySecretName"}
+      imageRegistrySecret: {}
+      upgradePolicy:
+        # -- the type of daemonset upgrade, RollingUpdate or OnDelete
+        upgradeStrategy: RollingUpdate
+        # -- the maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 1
+    metricsExporter:
+      # -- enable / disable device metrics exporter
+      enable: true
+      # -- type of service for exposing metrics endpoint, ClusterIP or NodePort
+      serviceType: ClusterIP
+      # -- internal port used for in-cluster and node access to pull metrics from the metrics-exporter (default 5000).
+      port: 5000
+      # -- external port for pulling metrics from outside the cluster for NodePort service, in the range 30000-32767 (assigned automatically by default)
+      nodePort: 32500
+      # -- metrics exporter image
+      image: rocm/device-metrics-exporter:v1.3.0
+      # -- metrics exporter image pull policy
+      imagePullPolicy: "IfNotPresent"
+      # -- name of the metrics exporter config map, e.g. {"name": "metricConfigMapName"}
+      config: {}
+      # -- metrics exporter tolerations
+      tolerations: []
+      # -- metrics exporter image pull secret, e.g. {"name": "pullSecretName"}
+      imageRegistrySecret: {}
+      # -- metrics exporter node selector, if not specified it will reuse spec.selector
+      selector: {}
+      upgradePolicy:
+        # -- the type of daemonset upgrade, RollingUpdate or OnDelete
+        upgradeStrategy: RollingUpdate
+        # -- the maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 1
+      rbacConfig:
+        # -- enable/disable kube rbac proxy
+        enable: false
+        # -- kube rbac proxy side car container image
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.1
+        # -- disable https protecting the proxy endpoint
+        disableHttps: false
+        # -- certificate secret to mount in kube-rbac container for TLS, self signed certificates will be generated by default, e.g. {"name": "secretName"}
+        secret: {}
+        # -- reference to a configmap containing the client CA (key: ca.crt) for mTLS client validation, e.g. {"name": "configMapName"}
+        clientCAConfigMap: {}
+        staticAuthorization:
+          # -- enables static authorization using client certificate CN
+          enable: false
+          # -- expected CN (Common Name) from client cert (e.g., Prometheus SA identity)
+          clientName: ""
+      prometheus:
+        serviceMonitor:
+          # -- enable or disable ServiceMonitor creation
+          enable: false
+          # -- frequency to scrape metrics. Accepts values with time unit suffix: "30s", "1m", "2h", "500ms"
+          interval: 30s
+          # -- define if Prometheus should attach node metadata to the target, e.g. {"node": "true"}
+          attachMetadata: {}
+          # -- choose the metric's labels on collisions with target labels
+          honorLabels: true
+          # -- control whether the scrape endpoints honor timestamps
+          honorTimestamps: false
+          # -- additional labels to add to the ServiceMonitor
+          labels: {}
+          # -- relabelConfigs to apply to samples before ingestion
+          relabelings: []
+          # -- relabeling rules applied to individual scraped metrics
+          metricRelabelings: []
+          # -- optional Prometheus authorization configuration for accessing the endpoint
+          authorization: {}
+          # -- TLS settings used by Prometheus to connect to the metrics endpoint
+          tlsConfig: {}
+    testRunner:
+      # -- enable / disable test runner
+      enable: false
+      # -- test runner image
+      image: docker.io/rocm/test-runner:v1.3.0
+      # -- test runner image pull policy
+      imagePullPolicy: "IfNotPresent" 
+      # -- test runner config map, e.g. {"name": "myConfigMap"}
+      config: {}
+      logsLocation:
+        # -- test runner internal mounted directory to save test run logs
+        mountPath: "/var/log/amd-test-runner" 
+        # -- host directory to save test run logs
+        hostPath: "/var/log/amd-test-runner"
+        # -- a list of secrets that contain connectivity info to multiple cloud providers
+        logsExportSecrets: []
+      upgradePolicy:
+        # -- the type of daemonset upgrade, RollingUpdate or OnDelete
+        upgradeStrategy: RollingUpdate
+        # -- the maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 1
+      # -- test runner tolerations
+      tolerations: []
+      # -- test runner image pull secret
+      imageRegistrySecret: {}
+      # -- test runner node selector, if not specified it will reuse spec.selector
+      selector: {}
+    configManager:
+      # -- enable/disable the config manager 
+      enable: false
+      # -- config manager image
+      image: rocm/device-config-manager:v1.3.0
+      # -- image pull policy for config manager image
+      imagePullPolicy: IfNotPresent
+      # -- image pull secret for config manager image, e.g. {"name": "myPullSecret"}
+      imageRegistrySecret: {}
+      # -- config map for config manager, e.g. {"name": "myConfigMap"}
+      config: {}
+      # -- node selector for config manager, if not specified it will reuse spec.selector
+      selector: {}
+      upgradePolicy:
+        # -- the type of daemonset upgrade, RollingUpdate or OnDelete
+        upgradeStrategy: RollingUpdate
+        # -- the maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 1
+      # -- config manager tolerations
+      configManagerTolerations: []
+
 # AMD GPU operator controller related configs
 controllerManager:
   manager:

--- a/tests/helm-e2e/Makefile
+++ b/tests/helm-e2e/Makefile
@@ -1,0 +1,14 @@
+ifneq ("$(wildcard ../../dev.env)","")
+    include ../../dev.env
+endif
+
+export GPU_OPERATOR_CHART
+
+.DEFAULT: all
+.PHONY: all lint
+all:
+	go test -test.timeout=360m -v
+lint:
+	@go fmt ./...
+	@goimports -w ./
+	@go vet ./...

--- a/tests/helm-e2e/doc.go
+++ b/tests/helm-e2e/doc.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"github.com/ROCm/gpu-operator/tests/e2e/client"
+	"k8s.io/client-go/kubernetes"
+)
+
+// E2ESuite e2e config
+type E2ESuite struct {
+	clientSet  *kubernetes.Clientset
+	dClient    *client.DeviceConfigClient
+	helmChart  string
+	ns         string
+	kubeconfig string
+}

--- a/tests/helm-e2e/e2e_test.go
+++ b/tests/helm-e2e/e2e_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	. "gopkg.in/check.v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+
+	"github.com/ROCm/gpu-operator/tests/e2e/client"
+)
+
+var logger = logrus.Logger{
+	Out: os.Stdout,
+	Formatter: &logrus.TextFormatter{
+		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+			return fmt.Sprintf("%v()", f.Function), fmt.Sprintf("%v:%v", path.Base(f.File), f.Line)
+		},
+	},
+	Hooks:        make(logrus.LevelHooks),
+	Level:        logrus.InfoLevel,
+	ExitFunc:     os.Exit,
+	ReportCaller: true,
+}
+
+var kubeConfig = flag.String("kubeConfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "absolute path to the kubeconfig file")
+var helmChart = flag.String("helmchart", "", "helmchart")
+var operatorNS = flag.String("namespace", "kube-amd-gpu", "namespace")
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&E2ESuite{})
+
+func (s *E2ESuite) SetUpSuite(c *C) {
+	logger.Infof("setupSuite:")
+	s.helmChart = *helmChart
+	s.kubeconfig = *kubeConfig
+	s.ns = *operatorNS
+
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", s.kubeconfig)
+	if err != nil {
+		c.Fatalf("Error: %v", err.Error())
+	}
+
+	dcCli, err := client.Client(config)
+	if err != nil {
+		c.Fatalf("Error: %v", err.Error())
+	}
+	s.dClient = dcCli
+
+	// creates the clientset
+	cs, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		c.Fatalf("Error: %v", err.Error())
+	}
+	s.clientSet = cs
+
+	cmd := exec.Command("helm", "delete", releaseName, "-n", s.ns)
+	logger.Info(fmt.Sprintf("cleaning up leftover helm chart in case test case forgot to uninstall: %+v", cmd.String()))
+	err = cmd.Run()
+	if err != nil {
+		logger.Info(fmt.Sprintf("pre-suite helm clean up return %+v, ignoring the error to execute test cases", err))
+	}
+}
+
+func (s *E2ESuite) SetUpTest(c *C) {
+	logger.Info("setupTest:")
+}
+func (s *E2ESuite) TearDownTest(c *C) {
+	logger.Info("TearDownTest:")
+	cmd := exec.Command("helm", "delete", releaseName, "-n", s.ns)
+	logger.Info(fmt.Sprintf("cleaning up leftover helm chart in case test case forgot to uninstall: %+v", cmd.String()))
+	err := cmd.Run()
+	if err != nil {
+		logger.Info(fmt.Sprintf("post-test helm clean up return %+v, ignoring the error to execute the next test case", err))
+	}
+
+	devCfgList, err := s.dClient.DeviceConfigs(s.ns).List(v1.ListOptions{})
+	if err == nil {
+		assert.Error(c, err, "expect error for listing DeviceConfig but got nil, CRD should have been deleted")
+	}
+	if devCfgList != nil {
+		assert.True(c, len(devCfgList.Items) == 0, fmt.Sprintf("expect all DeviceConfig got deleted after uninstalling helm chart but got %+v", devCfgList.Items))
+	}
+}
+
+func (s *E2ESuite) TearDownSuite(c *C) {
+	logger.Info("TearDownSuite:")
+}

--- a/tests/helm-e2e/helm_e2e_test.go
+++ b/tests/helm-e2e/helm_e2e_test.go
@@ -1,0 +1,858 @@
+/*
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the \"License\");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an \"AS IS\" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	. "gopkg.in/check.v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/ROCm/gpu-operator/api/v1alpha1"
+)
+
+const (
+	releaseName             = "amd-gpu-operator"
+	defaultDeviceConfigName = "default"
+	tmpValuesYamlPath       = "/tmp/values.yaml"
+)
+
+var (
+	boolTrue      = true
+	boolFalse     = false
+	testLabelName = "test123"
+)
+
+func (s *E2ESuite) installHelmChart(c *C, expectErr bool, extraArgs []string) {
+	helmChartPath, ok := os.LookupEnv("GPU_OPERATOR_CHART")
+	if !ok {
+		c.Fatalf("failed to get helm chart path from env GPU_OPERATOR_CHART")
+	}
+	args := []string{"install", releaseName, "-n", s.ns, helmChartPath}
+	args = append(args, extraArgs...)
+	cmd := exec.Command("helm", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	logger.Infof("Running command %+v", cmd.String())
+	if err := cmd.Run(); err != nil && !expectErr {
+		c.Fatalf("failed to install helm chart err %+v %+v", err, stderr.String())
+	}
+}
+
+func (s *E2ESuite) uninstallHelmChart(c *C, expectErr bool, extraArgs []string) {
+	args := []string{"delete", releaseName, "-n", s.ns}
+	args = append(args, extraArgs...)
+	cmd := exec.Command("helm", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	logger.Infof("Running command %+v", cmd.String())
+	if err := cmd.Run(); err != nil && !expectErr {
+		c.Fatalf("failed to uninstall helm chart err %+v %+v", err, stderr.String())
+	}
+}
+
+func (s *E2ESuite) upgradeHelmChart(c *C, expectErr bool, extraArgs []string) {
+	helmChartPath, ok := os.LookupEnv("GPU_OPERATOR_CHART")
+	if !ok {
+		c.Fatalf("failed to get helm chart path from env GPU_OPERATOR_CHART")
+	}
+	args := []string{"upgrade", releaseName, "-n", s.ns, helmChartPath}
+	args = append(args, extraArgs...)
+	cmd := exec.Command("helm", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	logger.Infof("Running command %+v", cmd.String())
+	if err := cmd.Run(); err != nil && !expectErr {
+		c.Fatalf("failed to upgrade helm chart err %+v %+v", err, stderr.String())
+	}
+}
+
+func (s *E2ESuite) verifyDefaultDeviceConfig(c *C, expect bool,
+	expectSpec *v1alpha1.DeviceConfigSpec,
+	verifyFunc func(expect, actual *v1alpha1.DeviceConfigSpec) bool) {
+	devCfgList, err := s.dClient.DeviceConfigs(s.ns).List(v1.ListOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		assert.NoError(c, err, "error listing DeviceConfig")
+	}
+	if !expect && err != nil {
+		// default CR was removed and even CRD was removed
+		return
+	}
+	if !expect && err == nil && devCfgList != nil && len(devCfgList.Items) == 0 {
+		// default CR was removed but CRD was not removed yet
+		return
+	}
+	if expect && err == nil && devCfgList != nil {
+		// make sure only one default CR exists
+		assert.True(c, len(devCfgList.Items) == 1,
+			"expect only one default DeviceConfig but got %+v %+v",
+			len(devCfgList.Items), devCfgList.Items)
+		// verify metadata
+		assert.True(c, devCfgList.Items[0].Name == defaultDeviceConfigName,
+			"expect default DeviceConfig name to be %v but got %v",
+			defaultDeviceConfigName, devCfgList.Items[0].Name)
+		assert.True(c, devCfgList.Items[0].Namespace == s.ns,
+			"expect default DeviceConfig namespace to be %v but got %v",
+			s.ns, devCfgList.Items[0].Namespace)
+		// verify spec
+		if expectSpec != nil && verifyFunc != nil {
+			assert.True(c, verifyFunc(expectSpec, &devCfgList.Items[0].Spec),
+				fmt.Sprintf("expect %+v got %+v", expectSpec, &devCfgList.Items[0].Spec))
+		}
+		return
+	}
+	c.Fatalf("unexpected default CR, expect %+v list error %+v devCfgList %+v",
+		expect, err, devCfgList)
+}
+
+func (s *E2ESuite) verifySelector(expect, actual *v1alpha1.DeviceConfigSpec) bool {
+	return expect != nil && actual != nil &&
+		reflect.DeepEqual(expect.Selector, actual.Selector)
+}
+
+func (s *E2ESuite) verifyDriver(expect, actual *v1alpha1.DeviceConfigSpec) bool {
+	return expect != nil && actual != nil &&
+		reflect.DeepEqual(expect.Driver, actual.Driver)
+}
+
+func (s *E2ESuite) verifyCommonConfig(expect, actual *v1alpha1.DeviceConfigSpec) bool {
+	return expect != nil && actual != nil &&
+		reflect.DeepEqual(expect.CommonConfig, actual.CommonConfig)
+}
+
+func (s *E2ESuite) verifyMetricsExporter(expect, actual *v1alpha1.DeviceConfigSpec) bool {
+	return expect != nil && actual != nil &&
+		reflect.DeepEqual(expect.MetricsExporter, actual.MetricsExporter)
+}
+
+func (s *E2ESuite) verifyTestRunner(expect, actual *v1alpha1.DeviceConfigSpec) bool {
+	return expect != nil && actual != nil &&
+		reflect.DeepEqual(expect.TestRunner, actual.TestRunner)
+}
+
+func (s *E2ESuite) verifyConfigManager(expect, actual *v1alpha1.DeviceConfigSpec) bool {
+	return expect != nil && actual != nil &&
+		reflect.DeepEqual(expect.ConfigManager, actual.ConfigManager)
+}
+
+func (s *E2ESuite) verifyDevicePlugin(expect, actual *v1alpha1.DeviceConfigSpec) bool {
+	return expect != nil && actual != nil &&
+		reflect.DeepEqual(expect.DevicePlugin, actual.DevicePlugin)
+}
+
+func (s *E2ESuite) writeYAMLToFile(yamlContent string) error {
+	file, err := os.Create(tmpValuesYamlPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(yamlContent)
+	return err
+}
+
+func (s *E2ESuite) TestHelmInstallDefaultCR(c *C) {
+	// basic test case
+	// install + verify default CR was created
+	// uninstall + verify default CR was removed
+	s.installHelmChart(c, false, nil)
+	// verify default CR was created
+	s.verifyDefaultDeviceConfig(c, true, nil, nil)
+	s.uninstallHelmChart(c, false, nil)
+	// verify default CR was removed
+	s.verifyDefaultDeviceConfig(c, false, nil, nil)
+}
+
+func (s *E2ESuite) TestHelmUpgradeDefaultCR(c *C) {
+	s.installHelmChart(c, false, []string{"--set", "crds.defaultCR.install=false"})
+	// verify default CR was not created when disabled by --set
+	s.verifyDefaultDeviceConfig(c, false, nil, nil)
+	s.upgradeHelmChart(c, false, nil)
+	// verify that by default helm upgrade won't deploy default CR
+	s.verifyDefaultDeviceConfig(c, false, nil, nil)
+	s.upgradeHelmChart(c, false, []string{"--set", "crds.defaultCR.upgrade=true"})
+	// helm upgrade with --set to turn on crds.defaultCR.upgrade will deploy default CR
+	s.verifyDefaultDeviceConfig(c, true, nil, nil)
+	s.uninstallHelmChart(c, false, nil)
+	s.verifyDefaultDeviceConfig(c, false, nil, nil)
+
+	s.installHelmChart(c, false, nil)
+	s.verifyDefaultDeviceConfig(c, true, nil, nil)
+	s.upgradeHelmChart(c, false, nil)
+	// verify that default ugprade won't affect the existing default CR
+	s.verifyDefaultDeviceConfig(c, true, nil, nil)
+	s.uninstallHelmChart(c, false, nil)
+	s.verifyDefaultDeviceConfig(c, false, nil, nil)
+}
+
+func (s *E2ESuite) TestHelmRenderDefaultCR(c *C) {
+	testCases := []struct {
+		description          string
+		valuesYAML           string
+		extraArgs            []string
+		helmFunc             func(c *C, expectErr bool, extraArgs []string)
+		expectHelmCommandErr bool
+		expectDefaultCR      bool
+		expectSpec           *v1alpha1.DeviceConfigSpec
+		verifyFunc           func(expect, actual *v1alpha1.DeviceConfigSpec) bool
+	}{
+		{
+			description: "invalid values.yaml",
+			valuesYAML: `
+<invalid format of yaml file>
+`,
+			extraArgs:            []string{"-f", tmpValuesYamlPath},
+			helmFunc:             s.installHelmChart,
+			expectHelmCommandErr: true,
+		},
+		{
+			description: "install with rendering spec.selector",
+			valuesYAML: `
+deviceConfig:
+  spec:
+    selector:
+      kubernetes.io/hostname: "node123"
+      feature.node.kubernetes.io/amd-gpu: "true"
+`,
+			extraArgs:            []string{"-f", tmpValuesYamlPath},
+			helmFunc:             s.installHelmChart,
+			expectHelmCommandErr: false,
+			expectDefaultCR:      true,
+			expectSpec: &v1alpha1.DeviceConfigSpec{
+				Selector: map[string]string{
+					"kubernetes.io/hostname":             "node123",
+					"feature.node.kubernetes.io/amd-gpu": "true",
+				},
+			},
+			verifyFunc: s.verifySelector,
+		},
+		{
+			description: "upgrade with rendering spec.driver",
+			valuesYAML: `
+deviceConfig:
+  spec:
+    selector:
+      kubernetes.io/hostname: "node123"
+      feature.node.kubernetes.io/amd-gpu: "true"
+    driver:
+      enable: true
+      blacklist: true
+      image: "test.io/username/repo"
+      imageRegistrySecret:
+        name: pull-secret
+      imageRegistryTLS:
+        # -- set to true to use plain HTTP for driver image repository
+        insecure: true
+        # -- set to true to skip TLS validation for driver image repository
+        insecureSkipTLSVerify: true
+      version: "6.3.3"
+      imageSign:
+        keySecret:
+          name: privateKeySecret
+        certSecret:
+          name: publicKeySecret
+      upgradePolicy:
+        # -- enable/disable automatic driver upgrade feature 
+        enable: false
+        # -- how many nodes can be upgraded in parallel
+        maxParallelUpgrades: 5
+        # -- maximum number of nodes that can be in a failed upgrade state beyond which upgrades will stop to keep cluster at a minimal healthy state
+        maxUnavailableNodes: 50%
+        # -- whether reboot each worker node or not during the driver upgrade
+        rebootRequired: false
+        nodeDrainPolicy:
+          # -- whether force draining is allowed or not
+          force: false
+          # -- the length of time in seconds to wait before giving up drain, zero means infinite
+          timeoutSeconds: 600
+          # -- the time kubernetes waits for a pod to shut down gracefully after receiving a termination signal, zero means immediate, minus value means follow pod defined grace period
+          gracePeriodSeconds: -2
+        podDeletionPolicy:
+          # -- whether force deletion is allowed or not
+          force: false
+          # -- the length of time in seconds to wait before giving up on pod deletion, zero means infinite
+          timeoutSeconds: 600
+          # -- the time kubernetes waits for a pod to shut down gracefully after receiving a termination signal, zero means immediate, minus value means follow pod defined grace period
+          gracePeriodSeconds: -2
+`,
+			extraArgs:            []string{"-f", tmpValuesYamlPath, "--set", "crds.defaultCR.upgrade=true"},
+			helmFunc:             s.upgradeHelmChart,
+			expectHelmCommandErr: false,
+			expectDefaultCR:      true,
+			expectSpec: &v1alpha1.DeviceConfigSpec{
+				Driver: v1alpha1.DriverSpec{
+					Enable:    &boolTrue,
+					Blacklist: &boolTrue,
+					Image:     "test.io/username/repo",
+					ImageRegistrySecret: &corev1.LocalObjectReference{
+						Name: "pull-secret",
+					},
+					ImageRegistryTLS: v1alpha1.RegistryTLS{
+						Insecure:              &boolTrue,
+						InsecureSkipTLSVerify: &boolTrue,
+					},
+					Version: "6.3.3",
+					ImageSign: v1alpha1.ImageSignSpec{
+						KeySecret: &corev1.LocalObjectReference{
+							Name: "privateKeySecret",
+						},
+						CertSecret: &corev1.LocalObjectReference{
+							Name: "publicKeySecret",
+						},
+					},
+					UpgradePolicy: &v1alpha1.DriverUpgradePolicySpec{
+						Enable:              &boolFalse,
+						MaxParallelUpgrades: 5,
+						MaxUnavailableNodes: intstr.FromString("50%"),
+						RebootRequired:      &boolFalse,
+						NodeDrainPolicy: &v1alpha1.DrainSpec{
+							Force:              &boolFalse,
+							TimeoutSeconds:     600,
+							GracePeriodSeconds: -2,
+						},
+						PodDeletionPolicy: &v1alpha1.PodDeletionSpec{
+							Force:              &boolFalse,
+							TimeoutSeconds:     600,
+							GracePeriodSeconds: -2,
+						},
+					},
+				},
+			},
+			verifyFunc: s.verifyDriver,
+		},
+		{
+			description: "upgrade with rendering spec.commonConfig",
+			valuesYAML: `
+deviceConfig:
+  spec:
+    selector:
+      kubernetes.io/hostname: "node123"
+      feature.node.kubernetes.io/amd-gpu: "true"
+    driver:
+      enable: true
+      blacklist: true
+      image: "test.io/username/repo"
+    commonConfig:
+      # -- init container image
+      initContainerImage: busybox:1.37
+      utilsContainer:
+        # -- gpu operator utility container image
+        image: test.io/test/gpu-operator-utils:v1.3.0
+        # -- utility container image pull policy
+        imagePullPolicy: Always
+        # -- utility container image pull secret, e.g. {"name": "mySecretName"}
+        imageRegistrySecret:
+          name: mySecretName
+`,
+			extraArgs:            []string{"-f", tmpValuesYamlPath, "--set", "crds.defaultCR.upgrade=true"},
+			helmFunc:             s.upgradeHelmChart,
+			expectHelmCommandErr: false,
+			expectDefaultCR:      true,
+			expectSpec: &v1alpha1.DeviceConfigSpec{
+				CommonConfig: v1alpha1.CommonConfigSpec{
+					InitContainerImage: "busybox:1.37",
+					UtilsContainer: v1alpha1.UtilsContainerSpec{
+						Image:           "test.io/test/gpu-operator-utils:v1.3.0",
+						ImagePullPolicy: "Always",
+						ImageRegistrySecret: &corev1.LocalObjectReference{
+							Name: "mySecretName",
+						},
+					},
+				},
+			},
+			verifyFunc: s.verifyCommonConfig,
+		},
+		{
+			description: "upgrade with rendering spec.devicePlugin",
+			valuesYAML: `
+deviceConfig:
+  spec:
+    selector:
+      kubernetes.io/hostname: "node123"
+      feature.node.kubernetes.io/amd-gpu: "true"
+    driver:
+      enable: true
+      blacklist: true
+      image: "test.io/username/repo"
+    commonConfig:
+      # -- init container image
+      initContainerImage: busybox:1.37
+    devicePlugin:
+      # -- device plugin image
+      devicePluginImage: test/k8s-device-plugin:latest
+      # -- device plugin image pull policy
+      devicePluginImagePullPolicy: Always
+      # -- device plugin tolerations
+      devicePluginTolerations:
+        - key: "example-key"
+          operator: "Equal"
+          value: "example-value"
+          effect: "NoSchedule"
+        - key: "example-key2"
+          operator: "Equal"
+          value: "example-value2"
+          effect: "NoExecute"
+      devicePluginArguments:
+        resource_naming_strategy: mixed
+      # -- enable / disable node labeller
+      enableNodeLabeller: false
+      # -- node labeller image
+      nodeLabellerImage: test/k8s-device-plugin:labeller-latest
+      # -- node labeller image pull policy
+      nodeLabellerImagePullPolicy: Always
+      # -- node labeller tolerations
+      nodeLabellerTolerations:
+        - key: "example-key"
+          operator: "Equal"
+          value: "example-value"
+          effect: "NoSchedule"
+      # -- pass supported labels while starting node labeller daemonset, default ["vram", "cu-count", "simd-count", "device-id", "family", "product-name", "driver-version"], also support ["compute-memory-partition", "compute-partitioning-supported", "memory-partitioning-supported"]
+      nodeLabellerArguments:
+        - vram
+        - cu-count
+      # -- image pull secret for device plugin and node labeller, e.g. {"name": "mySecretName"}
+      imageRegistrySecret:
+        name: mySecretName
+      upgradePolicy:
+        # -- the type of daemonset upgrade, RollingUpdate or OnDelete
+        upgradeStrategy: OnDelete
+        # -- the maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 5
+`,
+			extraArgs:            []string{"-f", tmpValuesYamlPath, "--set", "crds.defaultCR.upgrade=true"},
+			helmFunc:             s.upgradeHelmChart,
+			expectHelmCommandErr: false,
+			expectDefaultCR:      true,
+			expectSpec: &v1alpha1.DeviceConfigSpec{
+				DevicePlugin: v1alpha1.DevicePluginSpec{
+					DevicePluginImage:           "test/k8s-device-plugin:latest",
+					DevicePluginImagePullPolicy: "Always",
+					DevicePluginTolerations: []corev1.Toleration{
+						{
+							Key:      "example-key",
+							Operator: corev1.TolerationOpEqual,
+							Value:    "example-value",
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+						{
+							Key:      "example-key2",
+							Operator: corev1.TolerationOpEqual,
+							Value:    "example-value2",
+							Effect:   corev1.TaintEffectNoExecute,
+						},
+					},
+					DevicePluginArguments: map[string]string{
+						"resource_naming_strategy": "mixed",
+					},
+					EnableNodeLabeller:          &boolFalse,
+					NodeLabellerImage:           "test/k8s-device-plugin:labeller-latest",
+					NodeLabellerImagePullPolicy: "Always",
+					NodeLabellerTolerations: []corev1.Toleration{
+						{
+							Key:      "example-key",
+							Operator: corev1.TolerationOpEqual,
+							Value:    "example-value",
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+					NodeLabellerArguments: []string{"vram", "cu-count"},
+					ImageRegistrySecret: &corev1.LocalObjectReference{
+						Name: "mySecretName",
+					},
+					UpgradePolicy: &v1alpha1.DaemonSetUpgradeSpec{
+						UpgradeStrategy: "OnDelete",
+						MaxUnavailable:  5,
+					},
+				},
+			},
+			verifyFunc: s.verifyDevicePlugin,
+		},
+		{
+			description: "upgrade with rendering spec.testRunner",
+			valuesYAML: `
+deviceConfig:
+  spec:
+    selector:
+      kubernetes.io/hostname: "node123"
+      feature.node.kubernetes.io/amd-gpu: "true"
+    driver:
+      enable: true
+      blacklist: true
+      image: "test.io/username/repo"
+    commonConfig:
+      # -- init container image
+      initContainerImage: busybox:1.37
+    devicePlugin:
+      # -- device plugin image
+      devicePluginImage: test/k8s-device-plugin:latest
+      # -- device plugin image pull policy
+      devicePluginImagePullPolicy: Always
+    testRunner:
+      # -- enable / disable test runner
+      enable: true
+      image: test.io/test/test-runner:v1.3.0
+      imagePullPolicy: "Always" 
+      # -- test runner config map, e.g. {"name": "myConfigMap"}
+      config:
+        name: myConfigMap
+      logsLocation:
+        # -- test runner internal mounted directory to save test run logs
+        mountPath: "/var/log/amd-test-runner123" 
+        # -- host directory to save test run logs
+        hostPath: "/var/log/amd-test-runner321"
+        logsExportSecrets:
+          - name: azure
+          - name: gcp
+          - name: s3
+      upgradePolicy:
+        upgradeStrategy: OnDelete
+        maxUnavailable: 10
+      tolerations:
+        - key: "example-key"
+          operator: "Equal"
+          value: "example-value"
+          effect: "NoSchedule"
+      imageRegistrySecret:
+        name: mySecret123
+      selector:
+        "testRun": "true"
+`,
+			extraArgs:            []string{"-f", tmpValuesYamlPath, "--set", "crds.defaultCR.upgrade=true"},
+			helmFunc:             s.upgradeHelmChart,
+			expectHelmCommandErr: false,
+			expectDefaultCR:      true,
+			expectSpec: &v1alpha1.DeviceConfigSpec{
+				TestRunner: v1alpha1.TestRunnerSpec{
+					Enable:          &boolTrue,
+					Image:           "test.io/test/test-runner:v1.3.0",
+					ImagePullPolicy: "Always",
+					Config: &corev1.LocalObjectReference{
+						Name: "myConfigMap",
+					},
+					LogsLocation: v1alpha1.LogsLocationConfig{
+						MountPath: "/var/log/amd-test-runner123",
+						HostPath:  "/var/log/amd-test-runner321",
+						LogsExportSecrets: []*corev1.LocalObjectReference{
+							{
+								Name: "azure",
+							},
+							{
+								Name: "gcp",
+							},
+							{
+								Name: "s3",
+							},
+						},
+					},
+					UpgradePolicy: &v1alpha1.DaemonSetUpgradeSpec{
+						UpgradeStrategy: "OnDelete",
+						MaxUnavailable:  10,
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "example-key",
+							Operator: corev1.TolerationOpEqual,
+							Value:    "example-value",
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+					ImageRegistrySecret: &corev1.LocalObjectReference{
+						Name: "mySecret123",
+					},
+					Selector: map[string]string{
+						"testRun": "true",
+					},
+				},
+			},
+			verifyFunc: s.verifyTestRunner,
+		},
+		{
+			description: "upgrade with rendering spec.configManager",
+			valuesYAML: `
+deviceConfig:
+  spec:
+    selector:
+      kubernetes.io/hostname: "node123"
+      feature.node.kubernetes.io/amd-gpu: "true"
+    driver:
+      enable: true
+      blacklist: true
+      image: "test.io/username/repo"
+    commonConfig:
+      # -- init container image
+      initContainerImage: busybox:1.37
+    devicePlugin:
+      # -- device plugin image
+      devicePluginImage: test/k8s-device-plugin:latest
+      # -- device plugin image pull policy
+      devicePluginImagePullPolicy: Always
+    testRunner:
+      enable: true
+      image: test.io/test/test-runner:v1.3.0
+      imagePullPolicy: "Always"
+    configManager:
+      enable: true
+      image: test.io/test/device-config-manager:v1.3.0
+      imagePullPolicy: "Always"
+      imageRegistrySecret:
+        name: mySecret456
+      config:
+        name: myConfigMap
+      selector:
+        "dcm": "true"
+      upgradePolicy:
+        upgradeStrategy: OnDelete
+        maxUnavailable: 10
+      configManagerTolerations:
+        - key: "example-key"
+          operator: "Equal"
+          value: "example-value"
+          effect: "NoSchedule"
+`,
+			extraArgs:            []string{"-f", tmpValuesYamlPath, "--set", "crds.defaultCR.upgrade=true"},
+			helmFunc:             s.upgradeHelmChart,
+			expectHelmCommandErr: false,
+			expectDefaultCR:      true,
+			expectSpec: &v1alpha1.DeviceConfigSpec{
+				ConfigManager: v1alpha1.ConfigManagerSpec{
+					Enable:          &boolTrue,
+					Image:           "test.io/test/device-config-manager:v1.3.0",
+					ImagePullPolicy: "Always",
+					ImageRegistrySecret: &corev1.LocalObjectReference{
+						Name: "mySecret456",
+					},
+					Config: &corev1.LocalObjectReference{
+						Name: "myConfigMap",
+					},
+					Selector: map[string]string{
+						"dcm": "true",
+					},
+					UpgradePolicy: &v1alpha1.DaemonSetUpgradeSpec{
+						UpgradeStrategy: "OnDelete",
+						MaxUnavailable:  10,
+					},
+					ConfigManagerTolerations: []corev1.Toleration{
+						{
+							Key:      "example-key",
+							Operator: corev1.TolerationOpEqual,
+							Value:    "example-value",
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+			verifyFunc: s.verifyConfigManager,
+		},
+		{
+			description: "upgrade with rendering spec.metricsExporter",
+			valuesYAML: `
+deviceConfig:
+  spec:
+    selector:
+      kubernetes.io/hostname: "node123"
+      feature.node.kubernetes.io/amd-gpu: "true"
+    driver:
+      enable: true
+      blacklist: true
+      image: "test.io/username/repo"
+    commonConfig:
+      # -- init container image
+      initContainerImage: busybox:1.37
+    devicePlugin:
+      # -- device plugin image
+      devicePluginImage: test/k8s-device-plugin:latest
+      # -- device plugin image pull policy
+      devicePluginImagePullPolicy: Always
+    testRunner:
+      enable: true
+      image: test.io/test/test-runner:v1.3.0
+      imagePullPolicy: "Always"
+    configManager:
+      enable: true
+      image: test.io/test/device-config-manager:v1.3.0
+    metricsExporter:
+      enable: false
+      serviceType: NodePort
+      port: 5001
+      nodePort: 32501
+      image: test/device-metrics-exporter:v1.3.0
+      imagePullPolicy: "Always"
+      config:
+        name: metricsConfig
+      tolerations:
+        - key: "example-key"
+          operator: "Equal"
+          value: "example-value"
+          effect: "NoSchedule"
+      imageRegistrySecret:
+        name: mySecret123
+      selector:
+        "exporter": "true"
+      upgradePolicy:
+        upgradeStrategy: RollingUpdate
+        maxUnavailable: 5
+      rbacConfig:
+        enable: true
+        image: quay.io/brancz/kube-rbac-proxy:latest
+        disableHttps: false
+        secret:
+          name: rbacProxySecret
+        clientCAConfigMap:
+          name: clientCA
+        staticAuthorization:
+          enable: true
+          clientName: "test"
+      prometheus:
+        serviceMonitor:
+          enable: false
+          interval: 30s
+          attachMetadata:
+            node: true
+          honorLabels: false
+          honorTimestamps: true
+          labels:
+            source: exporter
+          relabelings:
+            - targetLabel: test1
+              replacement: test123
+              action: Replace
+          metricRelabelings:
+            - targetLabel: test2
+              replacement: test123
+              action: Replace
+          authorization:
+            type: Bearer
+            credentials:
+              name: test
+              key: test123
+          tlsConfig:
+            keyFile: /etc/credential
+`,
+			extraArgs:            []string{"-f", tmpValuesYamlPath, "--set", "crds.defaultCR.upgrade=true"},
+			helmFunc:             s.upgradeHelmChart,
+			expectHelmCommandErr: false,
+			expectDefaultCR:      true,
+			expectSpec: &v1alpha1.DeviceConfigSpec{
+				MetricsExporter: v1alpha1.MetricsExporterSpec{
+					Enable:          &boolFalse,
+					SvcType:         v1alpha1.ServiceTypeNodePort,
+					Port:            5001,
+					NodePort:        32501,
+					Image:           "test/device-metrics-exporter:v1.3.0",
+					ImagePullPolicy: "Always",
+					Config: v1alpha1.MetricsConfig{
+						Name: "metricsConfig",
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "example-key",
+							Operator: corev1.TolerationOpEqual,
+							Value:    "example-value",
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+					ImageRegistrySecret: &corev1.LocalObjectReference{
+						Name: "mySecret123",
+					},
+					Selector: map[string]string{
+						"exporter": "true",
+					},
+					UpgradePolicy: &v1alpha1.DaemonSetUpgradeSpec{
+						UpgradeStrategy: "RollingUpdate",
+						MaxUnavailable:  5,
+					},
+					RbacConfig: v1alpha1.KubeRbacConfig{
+						Enable:       &boolTrue,
+						Image:        "quay.io/brancz/kube-rbac-proxy:latest",
+						DisableHttps: &boolFalse,
+						Secret: &corev1.LocalObjectReference{
+							Name: "rbacProxySecret",
+						},
+						ClientCAConfigMap: &corev1.LocalObjectReference{
+							Name: "clientCA",
+						},
+						StaticAuthorization: &v1alpha1.StaticAuthConfig{
+							Enable:     boolTrue,
+							ClientName: "test",
+						},
+					},
+					Prometheus: &v1alpha1.PrometheusConfig{
+						ServiceMonitor: &v1alpha1.ServiceMonitorConfig{
+							Enable:   &boolFalse,
+							Interval: "30s",
+							AttachMetadata: &monitoringv1.AttachMetadata{
+								Node: &boolTrue,
+							},
+							HonorLabels:     &boolFalse,
+							HonorTimestamps: &boolTrue,
+							Labels: map[string]string{
+								"source": "exporter",
+							},
+							Relabelings: []monitoringv1.RelabelConfig{
+								{
+									TargetLabel: "test1",
+									Replacement: &testLabelName,
+									Action:      "Replace",
+								},
+							},
+							MetricRelabelings: []monitoringv1.RelabelConfig{
+								{
+									TargetLabel: "test2",
+									Replacement: &testLabelName,
+									Action:      "Replace",
+								},
+							},
+							Authorization: &monitoringv1.SafeAuthorization{
+								Type: "Bearer",
+								Credentials: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "test",
+									},
+									Key: "test123",
+								},
+							},
+							TLSConfig: &monitoringv1.TLSConfig{
+								KeyFile: "/etc/credential",
+							},
+						},
+					},
+				},
+			},
+			verifyFunc: s.verifyMetricsExporter,
+		},
+	}
+
+	for _, tc := range testCases {
+		logger.Info(fmt.Sprintf("Running test case %+v", tc.description))
+		assert.NoError(c, s.writeYAMLToFile(tc.valuesYAML),
+			"failed to prepare yaml file for test case %+v", tc.description)
+		tc.helmFunc(c, tc.expectHelmCommandErr, tc.extraArgs)
+		if tc.expectHelmCommandErr {
+			continue
+		}
+		s.verifyDefaultDeviceConfig(c, tc.expectDefaultCR, tc.expectSpec, tc.verifyFunc)
+	}
+}


### PR DESCRIPTION
Add a default `DefaultConfig` in the helm chart, with corresponding e2e test suite and docs change.

Related Issue: https://github.com/ROCm/gpu-operator/issues/150

1. Helm install:
* By default helm install will create a helm default DeviceConfig, it is configurable via changing values.yaml.
* Users can optionally turn it off during helm install. --set crds.defaultCR.install=false
2. Helm upgrade:
* By default NO default DeviceConfig will be created/patched.
* In that way, By Default, Users with existing DeviceConfigs,  upgrading to new version of helm chart will affect their existing DeviceConfig.
* Users can optionally turn on creating/patching the default DeviceConfig with new default values or customized values. They need to evaluate the risk of conflicting with their existing DeviceConfig then turn on this. --set crds.defaultCR.upgrade=true
 3. Helm delete:
 Behavior change:
* Previously pre-delete hook block the helm uninstall when there are DeviceConfigs still existing.
* Now helm pre-delete hook will automatically remove all existing DeviceConfigs then move forward to uninstall the whole chart.