### PR TITLE
[CP 769][DOC] Misc fix on helm installation description

### DIFF
--- a/docs/installation/kubernetes-helm.md
+++ b/docs/installation/kubernetes-helm.md
@@ -118,19 +118,21 @@ To install the latest version of the GPU Operator run the following Helm install
 ```bash
 helm install amd-gpu-operator rocm/gpu-operator-charts \
   --namespace kube-amd-gpu \
-  --create-namespace
+  --create-namespace \
   --version=v1.3.0
 ```
 
 ```{note}
 Installation Options
   - Skip NFD installation: `--set node-feature-discovery.enabled=false`
-  - Skip KMM installation: `--set kmm.enabled=false`
+  - Skip KMM installation: `--set kmm.enabled=false`. <br> Although KMM is a [Kubernetes-SIGs](https://github.com/kubernetes-sigs) maintained project, it is strongly recommended to use AMD optimized and published KMM images included in each operator release.
   - Disable default DeviceConfig installation: `--set crds.defaultCR.install=false`
 ```
 
-```{warning}
-  It is strongly recommended to use AMD-optimized KMM images included in the operator release.
+```{tip}
+1. Before v1.3.0 the gpu operator helm chart won't provide a default ```DeviceConfig```, you need to take extra step to create a ```DeviceConfig```.
+
+2. Starting from v1.3.0 the ```helm install``` command would support one-step installation + configuration, which would create a default ```DeviceConfig``` with default values, which may not work for all the users with different the deployment scenarios, please refer to {ref}`typical-deployment-scenarios` for more information and get corresponding ```helm install``` commands. 
 ```
 
 ### 3. Helm Chart Customization Parameters
@@ -471,7 +473,7 @@ kubectl get modules -n kube-amd-gpu
 - Check NFD status:
 
 ```bash
-kubectl get nodefeatures -n kube-amd-gpu
+kubectl get nodefeaturerules -n kube-amd-gpu
 ```
 
 For more detailed troubleshooting steps, see our [Troubleshooting Guide](../troubleshooting).

--- a/docs/slinky/slinky-example.md
+++ b/docs/slinky/slinky-example.md
@@ -11,6 +11,14 @@ cd example/slinky
 
 ## Installing Slinky Prerequisites
 
+Install AMD GPU Operator, configure the `DeviceConfig` and make sure that the device plugin is advertising the AMD GPU devices as allocatable resources
+
+```bash
+$ kubectl get node -oyaml | grep -i allocatable -A 10 | grep amd.com
+
+amd.com/gpu: "8"
+```
+
 The following steps for installing pre-requisites and installing Slinky have been taking from the SlinkProject/slinky-operator repo [quick-start guide](https://github.com/SlinkyProject/slurm-operator/blob/main/docs/quickstart.md)
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,6 +18,21 @@ To collect logs from the AMD GPU Operator:
 kubectl logs -n kube-amd-gpu <pod-name>
 ```
 
+
+## Potential Issues with default ``DeviceConfig``
+
+* Please refer to [Typical Deployment Scenarios](../usage.html#typical-deployment-scenarios) for more information and get corresponding ```helm install``` commands and configs that fits your specific use case.
+
+* If operand pods (e.g. device plugin, metrics exporter) are stuck in ``Init:0/1`` state, it means your GPU worker doesn't have GPU driver loaded or driver was not loaded properly. 
+
+    * If you try to use inbox or pre-installed driver please check the node ``dmesg`` to see why the driver was not loaded properly. 
+    
+    * If you want to deploy out-of-tree driver, we suggest check the `Driver Installation Guide <./drivers/installation.html>`_ then modify the default ``DeviceConfig`` to ask Operator to install the out-of-tree GPU driver for your worker nodes.
+
+```bash
+kubectl edit deviceconfigs -n kube-amd-gpu default
+```
+
 ## Debugging Driver Installation
 
 If the AMD GPU driver build fails:
@@ -42,7 +57,7 @@ kubectl get events -n kube-amd-gpu
 
 ## Using Techsupport-dump Tool
 
-The techsupport-dump tool can be used to collect system state and logs for debugging:
+The [techsupport-dump script](https://github.com/ROCm/gpu-operator/blob/main/tools/techsupport_dump.sh) can be used to collect system state and logs for debugging:
 
 ```bash
 ./tools/techsupport_dump.sh [-w] [-o yaml/json] [-k kubeconfig] <node-name/all>
@@ -53,3 +68,5 @@ Options:
 - `-w`: wide option
 - `-o yaml/json`: output format (default: json)
 - `-k kubeconfig`: path to kubeconfig (default: ~/.kube/config)
+
+Please file an issue with collected techsupport bundle on our [GitHub Issues](https://github.com/ROCm/gpu-operator/issues) page

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,14 +1,16 @@
 Quick Start Guide
 ===================
 
-Getting up and running with the AMD GPU Operator and Device Metrics Exporter on Kubernets is quick and easy. Below is a short guide on how to get started using the helm installation method on a standard Kubernetes install. Note that more detailed instructions on the different installation methods can be found on this site:
-<br>[GPU Operator Kubernetes Helm Install](../docs/installation/kubernetes-helm.md)
-<br>[GPU Operator Red Hat OpenShift Install](../docs/installation/openshift-olm.md)
+Getting up and running with the AMD GPU Operator and Device Metrics Exporter on Kubernetes is quick and easy. Below is a short guide on how to get started using the helm installation method on a standard Kubernetes install. Note that more detailed instructions on the different installation methods can be found on this site: 
+
+`GPU Operator Kubernetes Helm Install <../installation/kubernetes-helm.html>`_
+
+`GPU Operator Red Hat OpenShift Install <../installation/openshift-olm.html>`_
 
 Installing the GPU Operator
 ---------------------------
 
-1. The GPU Operator uses [cert-manager](https://cert-manager.io/) to manage certificates for MTLS communication between services. If you haven't already installed `cert-manager` as a prerequisite on your Kubernetes cluster, you'll need to install it as follows:
+1. The GPU Operator uses `cert-manager <https://cert-manager.io/>`_ to manage certificates for MTLS communication between services. If you haven't already installed ``cert-manager`` as a prerequisite on your Kubernetes cluster, you'll need to install it as follows:
 
 .. code-block:: bash
     
@@ -23,7 +25,7 @@ Installing the GPU Operator
         --set crds.enabled=true
 
 
-2. Once `cert-manager` is installed, you're just a few commands away from installing the GPU Operating and having a fully managed GPU infrastructure:
+2. Once ``cert-manager`` is installed, you're just a few commands away from installing the GPU Operating and having a fully managed GPU infrastructure, add the helm repository and fetch the latest helm charts:
 
 .. code-block:: bash
     
@@ -33,7 +35,22 @@ Installing the GPU Operator
 
 3. Install the GPU Operator
 
+By using ``helm install`` command you can install the AMD GPU Operator helm charts. 
+
+.. tip::
+
+      1. Before v1.3.0 the gpu operator helm chart won't provide a default ``DeviceConfig``, you need to take extra step to create a ``DeviceConfig``.
+      2. Starting from v1.3.0 the ``helm install`` command would support one-step installation + configuration, which would create a default ``DeviceConfig`` with default values, which may not work for all the users with different the deployment scenarios, please refer to :ref:`typical-deployment-scenarios`  for more information and get corresponding ``helm install`` commands. 
+
 .. tab-set::
+
+  .. tab-item:: v1.3.0
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.3.0
 
   .. tab-item:: v1.2.2
 
@@ -83,23 +100,202 @@ Installing the GPU Operator
             --namespace kube-amd-gpu --create-namespace \
             --version=v1.0.0   
 
-4. You should now see the GPU Operator component pods starting up in the namespace you specified above, `kube-amd-gpu`. You will also notice that the `gpu-operator-charts-controller-manager`, `kmm-controller` and `kmm-webhook-server` pods are in a pending state. This is because you need to label a node in your cluster as the control-plane node for those pods to run on:
+
+.. _typical-deployment-scenarios:
+Typical Deployment Scenarios
+--------------------------------
+
+1. Use VM worker node with VF-Passthrough GPU
+
+If you are using VM based GPU worker node with Virtual Function (VF) Passthrough powered by `AMD MxGPU GIM driver <https://github.com/amd/MxGPU-Virtualization>`_, the VF device would show up in the guest VM. 
+
+You need to adjust the default node selector to ``"feature.node.kubernetes.io/amd-vgpu":"true"`` to make the ``DeviceConfig`` work for your VM based cluster.
+
+
+.. tab-set::
+
+  .. tab-item:: v1.3.0
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.3.0 \
+            --set-json 'deviceConfig.spec.selector={"feature.node.kubernetes.io/amd-gpu":null,"feature.node.kubernetes.io/amd-vgpu":"true"}'
+
+  .. tab-item:: v1.2.2
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.2.2
+            # take extra step to create a DeviceConfig with spec.selector "feature.node.kubernetes.io/amd-vgpu":"true"
+
+  .. tab-item:: v1.2.1
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.2.1
+            # take extra step to create a DeviceConfig with spec.selector "feature.node.kubernetes.io/amd-vgpu":"true"
+
+  .. tab-item:: v1.2.0
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.2.0
+            # no amd-vgpu detection support at this version, please manually modify the DeviceConfig selector to make it select your worker nodes
+
+  .. tab-item:: v1.1.1
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.1.1
+            # no amd-vgpu detection support at this version, please manually modify the DeviceConfig selector to make it select your worker nodes
+
+  .. tab-item:: v1.1.0
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.1.0
+            # no amd-vgpu detection support at this version, please manually modify the DeviceConfig selector to make it select your worker nodes
+
+  .. tab-item:: v1.0.0
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.0.0 
+            # no amd-vgpu detection support at this version, please manually modify the DeviceConfig selector to make it select your worker nodes 
+
+
+2. Use GPU worker node without inbox / pre-installed driver
+
+If your worker node doesn't have inbox / pre-installed AMD GPU driver loaded, the operand (e.g. deivce plugin, metrics exporter) would stuck at ``Init 0/1`` pod state.
+
+If you plan to use GPU Operator to install out-of-tree driver on your worker nodes, please refer to `Driver Installation Guide <./drivers/installation.html>`_ to configure the default ``DeviceConfig``. Here are example commands:
+
+.. tab-set::
+
+  .. tab-item:: v1.3.0
+
+      .. code-block:: bash
+
+            # 1. prepare image registry to store driver image (e.g. dockerHub)
+            # 2. setup image registry secret: 
+            # kubectl create secret docker-registry mySecret -n kube-amd-gpu --docker-username=xxx --docker-password=xxx --docker-server=index.docker.io
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.3.0 \
+            --set deviceConfig.spec.driver.enable=true \
+            --set deviceConfig.spec.driver.blacklist=true \
+            --set deviceConfig.spec.driver.version=6.4 \
+            --set deviceConfig.spec.driver.image=docker.io/myUserName/amd-driver-image \
+            --set deviceConfig.spec.driver.imageRegistrySecret.name=mySecret
+
+  .. tab-item:: v1.2.2
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.2.2
+            # take extra step to create a DeviceConfig with proper configs in spec.driver
+
+  .. tab-item:: v1.2.1
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.2.1
+            # take extra step to create a DeviceConfig with proper configs in spec.driver
+
+  .. tab-item:: v1.2.0
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.2.0
+            # take extra step to create a DeviceConfig with proper configs in spec.driver
+
+  .. tab-item:: v1.1.1
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.1.1
+            # take extra step to create a DeviceConfig with proper configs in spec.driver
+
+  .. tab-item:: v1.1.0
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.1.0
+            # take extra step to create a DeviceConfig with proper configs in spec.driver
+
+  .. tab-item:: v1.0.0
+
+      .. code-block:: bash
+
+            helm install amd-gpu-operator rocm/gpu-operator-charts \
+            --namespace kube-amd-gpu --create-namespace \
+            --version=v1.0.0 
+            # take extra step to create a DeviceConfig with proper configs in spec.driver
+
+3. Deploy ``DeviceConfig`` separately without using the default one during helm charts installation
+
+You can use the option ``--set crds.defaultCR.install=false`` to disable the deployment of the default ``DeviceConfig`` then deploy it later in a separate step with your desired configuration.
+
+
+Verify Installation
+---------------------------
+
+After running ``helm install`` commands with proper configurations in ``values.yaml``. You should now see the GPU Operator pods starting up in the namespace you specified above, ``kube-amd-gpu``. Here is an example of one control plane node and one GPU worker node:
 
 .. code-block:: bash
 
-      # Label the control-plane node
-      kubectl label nodes <node-name> node-role.kubernetes.io/control-plane=
- 
-5. To deploy the Device Plugin, Node Labeller and Metrics exporter to your cluster you need to create a new DeviceConfig custom resource. For a full list of configurable options refer to the [Full Reference Config](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/fulldeviceconfig.html) documenattion. An [example DeviceConfig](https://github.com/ROCm/gpu-operator/blob/release-v1.1.0/example/deviceconfig_example.yaml) is supplied in the ROCm/gpu-operator repository which can be used to get going:
+  $ kubectl get deviceconfigs -n kube-amd-gpu
+  NAME      AGE
+  default   10m
 
-.. code-block:: bash
+  $ kubectl get pods -n kube-amd-gpu
+  NAME                                                              READY   STATUS     AGE
+  amd-gpu-operator-gpu-operator-charts-controller-manager-74nm5wt   1/1     Running    10m
+  amd-gpu-operator-kmm-controller-5c895cd594-h65nm                  1/1     Running    10m
+  amd-gpu-operator-kmm-webhook-server-76d6765d5b-g5g74              1/1     Running    10m
+  amd-gpu-operator-node-feature-discovery-gc-64c9b7dcd9-gz4g4       1/1     Running    10m
+  amd-gpu-operator-node-feature-discovery-master-7d69c9b6f9-hcrxm   1/1     Running    10m
+  amd-gpu-operator-node-feature-discovery-worker-jlzbs              1/1     Running    10m
+  default-device-plugin-9r9bh                                       1/1     Running    10m
+  default-metrics-exporter-6c7z5                                    1/1     Running    10m
+  default-node-labeller-xtwbm                                       1/1     Running    10m
 
-      # Apply the example DeviceConfig to enable the Device Plugin, Node Labeller and Metrics Exporter plugins
-      kubectl apply -f https://raw.githubusercontent.com/ROCm/gpu-operator/refs/heads/release-v1.1.0/example/deviceconfig_example.yaml
+* Controller components: ``gpu-operator-charts-controller-manager``, ``kmm-controller`` and ``kmm-webhook-server``
 
+* Operands: ``default-device-plugin``, ``default-node-labeller`` and ``default-metrics-exporter``
 
-</br>
-That's it! The GPU Operator components should now all be running. You can verify this by checking the namespace where the gpu-operator components are installed (default: `kube-amd-gpu`):
+Please refer to `TroubleShooting <./troubleshooting.html>`_ if any issue happened during the installation and configuration.
+
+For a full list of ``DeviceConfig`` configurable options refer to the `Full Reference Config <https://instinct.docs.amd.com/projects/gpu-operator/en/latest/fulldeviceconfig.html>`_ documentation. An example DeviceConfig is supplied in the ROCm/gpu-operator repository:     
+      .. code-block:: bash
+            
+            kubectl apply -f https://raw.githubusercontent.com/ROCm/gpu-operator/refs/heads/release-v1.3.0/example/deviceconfig_example.yaml
+
+That's it! The GPU Operator components should now all be running. You can verify this by checking the namespace where the gpu-operator components are installed (default: ``kube-amd-gpu``):
 
 .. code-block:: bash
       
@@ -119,12 +315,12 @@ To create a pod that uses a GPU, specify the GPU resource in your pod specificat
       spec:
         containers:
           - name: gpu-container
-            image: rocm/pytorch:latest
+            image: rocm/rocm-terminal:latest
             resources:
               limits:
                 amd.com/gpu: 1 # requesting 1 GPU
 
-Save this YAML to a file (e.g., `gpu-pod.yaml`) and create the pod:
+Save this YAML to a file (e.g., ``gpu-pod.yaml``) and create the pod:
 
 .. code-block:: bash
 
@@ -142,9 +338,9 @@ To check the status of GPUs in your cluster:
 Using amd-smi
 -------------
 
-To run `amd-smi` in a pod:
+To run ``amd-smi`` in a pod:
 
-- Create a YAML file named `amd-smi.yaml`:
+- Create a YAML file named ``amd-smi.yaml``:
 
 .. code-block:: yaml
 
@@ -154,7 +350,7 @@ To run `amd-smi` in a pod:
       name: amd-smi
       spec:
       containers:
-      - image: docker.io/rocm/pytorch:latest
+      - image: docker.io/rocm/rocm-terminal:latest
         name: amd-smi
         command: ["/bin/bash"]
         args: ["-c","amd-smi version && amd-smi monitor -ptum"]
@@ -171,7 +367,7 @@ To run `amd-smi` in a pod:
 
       kubectl create -f amd-smi.yaml
 
-- Check the logs and verify the output `amd-smi` reflects the expected ROCm version and GPU presence:
+- Check the logs and verify the output ``amd-smi`` reflects the expected ROCm version and GPU presence:
 
 .. code-block:: bash
 
@@ -184,9 +380,9 @@ To run `amd-smi` in a pod:
 Using rocminfo
 --------------
 
-To run `rocminfo` in a pod:
+To run ``rocminfo`` in a pod:
 
-- Create a YAML file named `rocminfo.yaml`:
+- Create a YAML file named ``rocminfo.yaml``:
 
 .. code-block:: yaml
 
@@ -196,10 +392,12 @@ To run `rocminfo` in a pod:
         name: rocminfo
       spec:
         containers:
-        - image: rocm/pytorch:latest
+        - image: docker.io/rocm/rocm-terminal:latest
           name: rocminfo
           command: ["/bin/sh","-c"]
           args: ["rocminfo"]
+          securityContext:
+            runAsUser: 0
           resources:
             limits:
               amd.com/gpu: 1
@@ -221,4 +419,4 @@ To run `rocminfo` in a pod:
 Configuring GPU Resources
 -------------------------
 
-Configuration parameters are documented in the [Custom Resource Installation Guide](./drivers/installation)
+Configuration parameters are documented in the `Custom Resource Installation Guide <./drivers/installation.html>`_


### PR DESCRIPTION
Several fixes on the existing docs:

1. The quick start doc has been switched to ```usage.rst``` but still use markdown format of docs, which makes the previous markdown docs didn't show up correctly in the website https://instinct.docs.amd.com/projects/gpu-operator/en/latest/usage.html . Fixing the syntax to meet the requirement of new rst docs.


2. Add the description of the default `DeviceConfig` that comes with the installation of v1.3.0 or later version helm charts.

3. In the example verification steps, move the image from `pytorch:latest` to `rocm-terminal:latest` because the former one is around 20GB after compression, which is too large. Related issue ticket is https://github.com/ROCm/gpu-operator/issues/200