### PR TITLE
[CP 776][Helm] Add MI350X and MI355X PF and VF device ID into NFD rule

### DIFF
--- a/docs/installation/openshift-olm.md
+++ b/docs/installation/openshift-olm.md
@@ -152,6 +152,8 @@ spec:
                   matchExpressions:
                     vendor: {op: In, value: ["1002"]}
                     device: {op: In, value: [
+                      "75a3", # MI355X
+                      "75a0", # MI350X
                       "74a5", # MI325X
                       "74a0", # MI300A
                       "74a1", # MI300X
@@ -162,6 +164,21 @@ spec:
                       "740c", # MI250/MI250X
                       "738c", # MI100
                       "738e"  # MI100
+                    ]}
+        - name: amd-vgpu
+          labels:
+            feature.node.kubernetes.io/amd-vgpu: "true"
+          matchAny:
+            - matchFeatures:
+                - feature: pci.device
+                  matchExpressions:
+                    vendor: {op: In, value: ["1002"]}
+                    device: {op: In, value: [
+                      "75b3", # MI355X VF
+                      "75b0", # MI350X VF
+                      "74b9", # MI325X VF
+                      "74b5", # MI300X VF
+                      "7410", # MI210 VF
                     ]}
 ```
 
@@ -186,6 +203,8 @@ spec:
               matchExpressions:
                 vendor: {op: In, value: ["1002"]}
                 device: {op: In, value: [
+                  "75a3", # MI355X
+                  "75a0", # MI350X
                   "74a5", # MI325X
                   "74a0", # MI300A
                   "74a1", # MI300X
@@ -196,6 +215,21 @@ spec:
                   "740c", # MI250/MI250X
                   "738c", # MI100
                   "738e" # MI100
+                ]}
+    - name: amd-vgpu
+      labels:
+        feature.node.kubernetes.io/amd-vgpu: "true"
+      matchAny:
+        - matchFeatures:
+            - feature: pci.device
+              matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: [
+                  "75b3", # MI355X VF
+                  "75b0", # MI350X VF
+                  "74b9", # MI325X VF
+                  "74b5", # MI300X VF
+                  "7410", # MI210 VF
                 ]}
 ```
 

--- a/hack/k8s-patch/template-patch/nfd-default-rule.yaml
+++ b/hack/k8s-patch/template-patch/nfd-default-rule.yaml
@@ -30,6 +30,16 @@ spec:
             matchExpressions:
                 vendor: {op: In, value: ["1002"]}
                 device: {op: In, value: ["74b9"]} # Mi325X VF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["75b0"]} # Mi350X VF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["75b3"]} # Mi355X VF
       # AMD Radeon Pro
       - matchFeatures:
           - feature: pci.device
@@ -46,6 +56,16 @@ spec:
       feature.node.kubernetes.io/amd-gpu: "true"
     matchAny:
       # AMD Instinct
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["75a3"]} # MI355X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["75a0"]} # MI350X
       - matchFeatures:
           - feature: pci.device
             matchExpressions:

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: file://./charts/kmm
   version: v1.0.0
 digest: sha256:f9a315dd2ce3d515ebf28c8e9a6a82158b493ca2686439ec381487761261b597
-generated: "2025-05-14T21:06:12.36965018Z"
+generated: "2025-06-16T20:35:57.346839217Z"

--- a/helm-charts-k8s/templates/nfd-default-rule.yaml
+++ b/helm-charts-k8s/templates/nfd-default-rule.yaml
@@ -30,6 +30,16 @@ spec:
             matchExpressions:
                 vendor: {op: In, value: ["1002"]}
                 device: {op: In, value: ["74b9"]} # Mi325X VF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["75b0"]} # Mi350X VF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["75b3"]} # Mi355X VF
       # AMD Radeon Pro
       - matchFeatures:
           - feature: pci.device
@@ -46,6 +56,16 @@ spec:
       feature.node.kubernetes.io/amd-gpu: "true"
     matchAny:
       # AMD Instinct
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["75a3"]} # MI355X
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+              vendor: {op: In, value: ["1002"]}
+              device: {op: In, value: ["75a0"]} # MI350X
       - matchFeatures:
           - feature: pci.device
             matchExpressions:


### PR DESCRIPTION
Add MI350X and MI355X PF and VF device ID to the default NFD rule so that the new release could support the auto-detection of the latest Instinct GPUs.