### PR TITLE
Makefile: fix default and docker/shell target commands not working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ default: docker-build-env ## Quick start to build everything from docker shell c
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-w $(CONTAINER_WORKDIR) \
 		$(DOCKER_BUILDER_IMAGE) \
-		bash -c "source ~/.bashrc && cd /gpu-operator && git config --global --add safe.directory /gpu-operator && make all && GOFLAGS=-mod=mod go run tools/build/copyright/main.go && make fmt"
+		'bash -c "source ~/.bashrc && cd /gpu-operator && git config --global --add safe.directory /gpu-operator && make all && GOFLAGS=-mod=mod go run tools/build/copyright/main.go && make fmt"'
 
 .PHONY: docker/shell
 docker/shell: docker-build-env ## Bring up and attach to a container that has dev environment configured.
@@ -151,7 +151,7 @@ docker/shell: docker-build-env ## Bring up and attach to a container that has de
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-w $(CONTAINER_WORKDIR) \
 		$(DOCKER_BUILDER_IMAGE) \
-		bash -c "cd /gpu-operator && git config --global --add safe.directory /gpu-operator && bash"
+		'bash -c "cd /gpu-operator && git config --global --add safe.directory /gpu-operator && bash"'
 
 .PHONY: all
 all: generate manager manifests helm-k8s helm-openshift bundle-build docker-build


### PR DESCRIPTION
The entrypoint.sh already runs the CMD under `bash -c` if not running as the default user. 

Hence during execution it actually becomes, `exec gosu "$USERNAME" bash -c bash -c "source ~/.bashrc && cd /gpu-operator && git config --global --add safe.directory /gpu-operator && make all && GOFLAGS=-mod=mod go run tools/build/copyright/main.go && make fmt"`


If we do `bash -c bash -c something`, it is essentially equivalent to running `bash -c bash` because `-c` and `something` are passed as the next arguments to the first bash program.

This fix will make sure that the whole command gets passed as the value for the -c option.

I did test this and it works good.