### PR TITLE
[DOC] Correct OLM example DeviceConfig namespace to be openshift-amd-gpu

### DIFF
--- a/docs/installation/openshift-olm.md
+++ b/docs/installation/openshift-olm.md
@@ -276,7 +276,7 @@ apiVersion: amd.com/v1alpha1
 kind: DeviceConfig
 metadata:
   name: test-cr
-  namespace: default
+  namespace: openshift-amd-gpu
 spec:
   driver:
     enable: true


### PR DESCRIPTION
Fixing the docs issue https://github.com/ROCm/gpu-operator/issues/245