### PR TITLE
[Feature] Add GIM driver dockerfile for OpenShift

### DIFF
--- a/internal/controllers/remediation_handler.go
+++ b/internal/controllers/remediation_handler.go
@@ -181,6 +181,7 @@ func (n *remediationMgr) HandleDelete(ctx context.Context, deviceConfig *amdv1al
 	wfList, err := n.helper.getWorkflowList(ctx, deviceConfig.Namespace)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to list workflows during delete")
+		return ctrl.Result{}, err
 	}
 
 	for _, wf := range wfList.Items {

--- a/internal/controllers/watchers/node.go
+++ b/internal/controllers/watchers/node.go
@@ -228,8 +228,8 @@ func (h *NodeEventHandler) handlePostProcess(ctx context.Context, logger logr.Lo
 		switch devConfig.Spec.Driver.DriverType {
 		case utils.DriverTypeVFPassthrough,
 			utils.DriverTypePFPassthrough:
-			logger.Info(fmt.Sprintf("node %v with configured PFPassthrough driver %v doesn't have VFIO binding ready, launching VFIO worker pod",
-				node.Name, driverTypeLabel))
+			logger.Info(fmt.Sprintf("node %v with configured %v driver %v doesn't have VFIO binding ready, launching VFIO worker pod",
+				devConfig.Spec.Driver.DriverType, node.Name, driverTypeLabel))
 			if err := h.workerMgr.Work(ctx, devConfig, node); err != nil {
 				logger.Error(err, "failed to create worker pod")
 			}

--- a/internal/kmmmodule/dockerfiles/DockerfileTemplate.coreos.gim
+++ b/internal/kmmmodule/dockerfiles/DockerfileTemplate.coreos.gim
@@ -1,0 +1,43 @@
+ARG DTK_AUTO
+
+FROM ${DTK_AUTO} as builder
+ARG KERNEL_VERSION
+ARG DRIVERS_VERSION
+ARG REPO_URL
+RUN dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm -y && \
+    crb enable && \
+    sed -i "s/\$releasever/9/g" /etc/yum.repos.d/epel*.repo && \
+    dnf install dnf-plugin-config-manager -y && \
+    dnf clean all
+
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/ && \
+    dnf config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/ && \
+    rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official && \
+    dnf clean all
+
+RUN dnf install automake bc -y && \
+    wget https://github.com/amd/MxGPU-Virtualization/releases/download/mainline%2F${DRIVERS_VERSION}/gim-dkms-${DRIVERS_VERSION}-0.noarch.rpm && \
+    dnf install ./gim-dkms-${DRIVERS_VERSION}-0.noarch.rpm -y && \
+    dnf clean all && \
+    rm ./gim-dkms-${DRIVERS_VERSION}-0.noarch.rpm && \
+    depmod ${KERNEL_VERSION} && \
+    find /lib/modules/${KERNEL_VERSION} -name "*.ko.xz" -exec xz -d {} \; && \
+    depmod ${KERNEL_VERSION}
+
+RUN mkdir -p /modules_files && \
+    mkdir -p /gim_ko_files && \
+    mkdir -p /kernel_files && \
+    cp /lib/modules/${KERNEL_VERSION}/modules.* /modules_files/ && \
+    cp -r /lib/modules/${KERNEL_VERSION}/extra/* /gim_ko_files/ && \
+    cp -r /lib/modules/${KERNEL_VERSION}/kernel/* /kernel_files/
+
+FROM registry.redhat.io/ubi9/ubi-minimal
+
+ARG KERNEL_VERSION
+
+RUN microdnf install -y kmod
+
+COPY --from=builder /gim_ko_files /opt/lib/modules/${KERNEL_VERSION}/extra
+COPY --from=builder /kernel_files /opt/lib/modules/${KERNEL_VERSION}/kernel
+COPY --from=builder /modules_files /opt/lib/modules/${KERNEL_VERSION}/


### PR DESCRIPTION
## Motivation

MxGPU GIM driver starts to support RHEL as host OS https://github.com/amd/MxGPU-Virtualization/releases, adding dockerfile to auto build GIM driver for OpenShift

## Technical Details

successfully built driver image:

`
coreos-417.94-5.14.0-427.50.1.el9_4.x86_64-vf-passthrough-8.2.0.K`
`
coreos-417.94-5.14.0-427.50.1.el9_4.x86_64-vf-passthrough-8.3.0.K`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
