### PR TITLE
[CP 939][Fix] Copy system inbox kmod to tolerate more amdgpu dependency chang…

### DIFF
--- a/internal/kmmmodule/dockerfiles/DockerfileTemplate.ubuntu
+++ b/internal/kmmmodule/dockerfiles/DockerfileTemplate.ubuntu
@@ -37,6 +37,6 @@ RUN apt-get update && apt-get install -y kmod
 RUN mkdir -p /opt/lib/modules/${KERNEL_FULL_VERSION}/updates/dkms/
 COPY --from=builder /lib/modules/${KERNEL_FULL_VERSION}/updates/dkms/amd* /opt/lib/modules/${KERNEL_FULL_VERSION}/updates/dkms/
 COPY --from=builder /lib/modules/${KERNEL_FULL_VERSION}/modules.* /opt/lib/modules/${KERNEL_FULL_VERSION}/
-RUN ln -s /lib/modules/${KERNEL_FULL_VERSION}/kernel /opt/lib/modules/${KERNEL_FULL_VERSION}/kernel
+COPY --from=builder /lib/modules/${KERNEL_FULL_VERSION}/kernel /opt/lib/modules/${KERNEL_FULL_VERSION}/kernel
 RUN mkdir -p /firmwareDir/updates/amdgpu
 COPY --from=builder /lib/firmware/updates/amdgpu /firmwareDir/updates/amdgpu


### PR DESCRIPTION
…es (#939)

## Motivation

# Issue

On Ubuntu 24.04 with kernel 6.8 GA kernel, driver management feature failed on installing ROCm driver 6.4.X

Error from KMM worker 

```bash
$ kubectl logs -n kube-amd-gpu   kmm-worker-leto-default2
Defaulted container "worker" out of: worker, image-extractor (init)
E0908 23:31:33.640688       1 funcs_kmod.go:15] "Could not get the git commit; using <undefined>" err="vcs.revision not found in build info settings" logger="kmm-worker"
I0908 23:31:33.640771       1 funcs_kmod.go:18] "Starting worker" logger="kmm-worker" version="0.0.1" git commit="<undefined>"
I0908 23:31:33.640782       1 funcs_kmod.go:30] "Reading config" logger="kmm-worker" path="/etc/kmm-worker/config.yaml"
I0908 23:31:33.641188       1 worker.go:76] "preparing firmware for loading" logger="kmm-worker" image directory="/tmp/firmwareDir/updates" host mount directory="/var/lib/firmware"
I0908 23:31:34.246886       1 modprobe.go:33] "Running modprobe" logger="kmm-worker" command="/sbin/modprobe -vd /tmp/opt amdgpu"
I0908 23:31:34.248939       1 cmdlog.go:70] "modprobe: ERROR: ctx=0x79e20a05eaa0 path=/tmp/opt/lib/modules/6.14.0-29-generic/kernel/drivers/gpu/drm/drm_exec.ko.zst error=No such file or directory" logger="kmm-worker.modprobe.stderr"
I0908 23:31:34.248991       1 cmdlog.go:70] "modprobe: ERROR: ctx=0x79e20a05eaa0 path=/tmp/opt/lib/modules/6.14.0-29-generic/kernel/drivers/gpu/drm/drm_exec.ko.zst error=No such file or directory" logger="kmm-worker.modprobe.stderr"
I0908 23:31:34.249029       1 cmdlog.go:70] "insmod /tmp/opt/lib/modules/6.8.0-79-generic/updates/dkms/amdgpu.ko " logger="kmm-worker.modprobe.stdout"
I0908 23:31:34.331589       1 cmdlog.go:70] "modprobe: ERROR: could not insert 'amdgpu': Unknown symbol in module, or unknown parameter (see dmesg)" logger="kmm-worker.modprobe.stderr"
E0908 23:31:34.332026       1 cmdutils.go:13] "Fatal error" err="error while waiting on the command: exit status 1" logger="kmm-worker"
```

# RCA

In Ubuntu 24.04 who is using latest linux GA kernel 6.X, the amdgpu kernel module dependency graph changed compared to Ubuntu 22.04 who is using 5.X GA kernal

the amdgpu kernel module start to depend on more kernel's inbox module. The new dependency on `drm_exec` kernel module is the root cause. That kernel module by default is not included on the original kernel module, it is part of the kernel headers. So either host server need to install `linux-modules-extra-$(uname -r)` or our driver image need to include that this kernel module.

## Technical Details

# Fix

Update 1 line in dockerfile, copy the amdgpu dependent kernel modules into driver image so that when loading the amdgpu kernel module, there won't be `No such file` error no matter the host server has installed kernel headers or not.

In 6.8.0 GA kernel
```bash
$ lsmod | grep amdgpu
amdgpu              19734528  3
amddrm_ttm_helper      12288  1 amdgpu
amddrm_buddy           24576  1 amdgpu
amdxcp                 12288  1 amdgpu
amd_sched              61440  1 amdgpu
drm_exec               12288  1 amdgpu    <---- this is newly found
drm_suballoc_helper    16384  1 amdgpu
drm_display_helper    237568  1 amdgpu
cec                    94208  2 drm_display_helper,amdgpu
video                  77824  1 amdgpu
amdttm                114688  2 amdgpu,amddrm_ttm_helper
amdkcl                 36864  3 amd_sched,amdttm,amdgpu
i2c_algo_bit           16384  2 igb,amdgpu
```

In 5.15.0- GA kernel 

```bash
$ lsmod | grep amdgpu
amdgpu              17170432  0
amddrm_ttm_helper      16384  1 amdgpu
amdttm                 94208  2 amdgpu,amddrm_ttm_helper
amdxcp                 16384  1 amdgpu
amddrm_buddy           20480  1 amdgpu
amd_sched              53248  1 amdgpu
amdkcl                 45056  3 amd_sched,amdttm,amdgpu
i2c_algo_bit           16384  2 mgag200,amdgpu
drm_kms_helper        315392  4 mgag200,amdgpu
drm                   622592  10 drm_kms_helper,amd_sched,amdttm,mgag200,amdgpu,amddrm_buddy,amdkcl,amddrm_ttm_helper,amdxcp
```

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
