### PR TITLE
make utility image for remediation workflow configurable (#972)

### DIFF
--- a/api/v1alpha1/deviceconfig_types.go
+++ b/api/v1alpha1/deviceconfig_types.go
@@ -97,6 +97,12 @@ type RemediationWorkflowSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TtlForFailedWorkflows",xDescriptors={"urn:alm:descriptor:com.amd.deviceconfigs:ttlForFailedWorkflows"}
 	// +kubebuilder:default:=24
 	TtlForFailedWorkflows int `json:"ttlForFailedWorkflows,omitempty"`
+
+	// Tester image used to run tests and verify if remediation fixed the reported problem.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TesterImage",xDescriptors={"urn:alm:descriptor:com.amd.deviceconfigs:testerImage"}
+	// +optional
+	// +kubebuilder:validation:Pattern=`^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$`
+	TesterImage string `json:"testerImage,omitempty"`
 }
 
 type RegistryTLS struct {

--- a/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -669,6 +669,12 @@ spec:
         path: remediationWorkflow.enable
         x-descriptors:
         - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: Tester image used to run tests and verify if remediation fixed
+          the reported problem.
+        displayName: TesterImage
+        path: remediationWorkflow.testerImage
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:testerImage
       - description: Time to live for argo workflow object and its pods for a failed
           workflow in hours. By default, it is set to 24 hours
         displayName: TtlForFailedWorkflows

--- a/bundle/manifests/amd.com_deviceconfigs.yaml
+++ b/bundle/manifests/amd.com_deviceconfigs.yaml
@@ -1301,6 +1301,11 @@ spec:
                       enable remediation workflows. disabled by default
                       enable if operator should automatically handle remediation of node incase of gpu issues
                     type: boolean
+                  testerImage:
+                    description: Tester image used to run tests and verify if remediation
+                      fixed the reported problem.
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
                   ttlForFailedWorkflows:
                     default: 24
                     description: Time to live for argo workflow object and its pods

--- a/config/crd/bases/amd.com_deviceconfigs.yaml
+++ b/config/crd/bases/amd.com_deviceconfigs.yaml
@@ -1297,6 +1297,11 @@ spec:
                       enable remediation workflows. disabled by default
                       enable if operator should automatically handle remediation of node incase of gpu issues
                     type: boolean
+                  testerImage:
+                    description: Tester image used to run tests and verify if remediation
+                      fixed the reported problem.
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
                   ttlForFailedWorkflows:
                     default: 24
                     description: Time to live for argo workflow object and its pods

--- a/config/manifests/bases/amd-gpu-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/amd-gpu-operator.clusterserviceversion.yaml
@@ -640,6 +640,12 @@ spec:
         path: remediationWorkflow.enable
         x-descriptors:
         - urn:alm:descriptor:com.amd.deviceconfigs:enable
+      - description: Tester image used to run tests and verify if remediation fixed
+          the reported problem.
+        displayName: TesterImage
+        path: remediationWorkflow.testerImage
+        x-descriptors:
+        - urn:alm:descriptor:com.amd.deviceconfigs:testerImage
       - description: Time to live for argo workflow object and its pods for a failed
           workflow in hours. By default, it is set to 24 hours
         displayName: TtlForFailedWorkflows

--- a/docs/autoremediation/auto-remediation.md
+++ b/docs/autoremediation/auto-remediation.md
@@ -34,6 +34,10 @@ GPU Operator creates the `workflow` which invokes the `workflow-template` to tri
 
 GPU Operator will handle adding this toleration for in-house components like KMM, metrics-exporter which should stay running during the workflow run
 
+-> Remediation workflow uses a utility image for executing the steps. Specify the utility image in `Spec.CommonConfig.UtilsContainer` section of Device Config. If the UtilsContainer section is not specified, default image used is `docker.io/rocm/gpu-operator-utils:latest`
+
+-> Specify the test runner image in field `RemediationWorkflow.TesterImage`. The image can be one of the images supported by `Spec.TestRunner.Image`. This image is used to test the GPUs after the remediation process is performed. If the field is not specified, default image used is `registry.test.pensando.io:5000/test-runner:agfhc-latest`.
+
 -> If a workflow runs and fails, the node will remain in tainted state. If the user wants to go ahead and make the node schedulable again for workloads, the node should be untainted with:
   `kubectl taint node <node-name> amd-gpu-unhealthy:NoSchedule-`
 

--- a/helm-charts-k8s/crds/deviceconfig-crd.yaml
+++ b/helm-charts-k8s/crds/deviceconfig-crd.yaml
@@ -1303,6 +1303,11 @@ spec:
                       enable remediation workflows. disabled by default
                       enable if operator should automatically handle remediation of node incase of gpu issues
                     type: boolean
+                  testerImage:
+                    description: Tester image used to run tests and verify if remediation
+                      fixed the reported problem.
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
                   ttlForFailedWorkflows:
                     default: 24
                     description: Time to live for argo workflow object and its pods

--- a/helm-charts-openshift/crds/deviceconfig-crd.yaml
+++ b/helm-charts-openshift/crds/deviceconfig-crd.yaml
@@ -1303,6 +1303,11 @@ spec:
                       enable remediation workflows. disabled by default
                       enable if operator should automatically handle remediation of node incase of gpu issues
                     type: boolean
+                  testerImage:
+                    description: Tester image used to run tests and verify if remediation
+                      fixed the reported problem.
+                    pattern: ^([a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?)(/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-z0-9._-]+)?(?:@[a-zA-Z0-9]+:[a-f0-9]+)?$
+                    type: string
                   ttlForFailedWorkflows:
                     default: 24
                     description: Time to live for argo workflow object and its pods

--- a/internal/controllers/mock_remediation_handler.go
+++ b/internal/controllers/mock_remediation_handler.go
@@ -156,18 +156,18 @@ func (mr *MockremediationMgrHelperAPIMockRecorder) createDefaultObjects(ctx, dev
 }
 
 // createDefaultWorkflowTemplate mocks base method.
-func (m *MockremediationMgrHelperAPI) createDefaultWorkflowTemplate(ctx context.Context, namespace string) (*v1alpha10.WorkflowTemplate, error) {
+func (m *MockremediationMgrHelperAPI) createDefaultWorkflowTemplate(ctx context.Context, devConfig *v1alpha1.DeviceConfig) (*v1alpha10.WorkflowTemplate, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "createDefaultWorkflowTemplate", ctx, namespace)
+	ret := m.ctrl.Call(m, "createDefaultWorkflowTemplate", ctx, devConfig)
 	ret0, _ := ret[0].(*v1alpha10.WorkflowTemplate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // createDefaultWorkflowTemplate indicates an expected call of createDefaultWorkflowTemplate.
-func (mr *MockremediationMgrHelperAPIMockRecorder) createDefaultWorkflowTemplate(ctx, namespace any) *gomock.Call {
+func (mr *MockremediationMgrHelperAPIMockRecorder) createDefaultWorkflowTemplate(ctx, devConfig any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "createDefaultWorkflowTemplate", reflect.TypeOf((*MockremediationMgrHelperAPI)(nil).createDefaultWorkflowTemplate), ctx, namespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "createDefaultWorkflowTemplate", reflect.TypeOf((*MockremediationMgrHelperAPI)(nil).createDefaultWorkflowTemplate), ctx, devConfig)
 }
 
 // createWorkflow mocks base method.
@@ -255,6 +255,20 @@ func (m *MockremediationMgrHelperAPI) getWorkflowTemplate(ctx context.Context, w
 func (mr *MockremediationMgrHelperAPIMockRecorder) getWorkflowTemplate(ctx, workflowTemplateName, namespace any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getWorkflowTemplate", reflect.TypeOf((*MockremediationMgrHelperAPI)(nil).getWorkflowTemplate), ctx, workflowTemplateName, namespace)
+}
+
+// getWorkflowUtilityImage mocks base method.
+func (m *MockremediationMgrHelperAPI) getWorkflowUtilityImage(devConfig *v1alpha1.DeviceConfig) v1.Container {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getWorkflowUtilityImage", devConfig)
+	ret0, _ := ret[0].(v1.Container)
+	return ret0
+}
+
+// getWorkflowUtilityImage indicates an expected call of getWorkflowUtilityImage.
+func (mr *MockremediationMgrHelperAPIMockRecorder) getWorkflowUtilityImage(devConfig any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getWorkflowUtilityImage", reflect.TypeOf((*MockremediationMgrHelperAPI)(nil).getWorkflowUtilityImage), devConfig)
 }
 
 // handleExistingWorkflowsOnNode mocks base method.

--- a/internal/utils_container/Dockerfile
+++ b/internal/utils_container/Dockerfile
@@ -9,11 +9,19 @@ LABEL summary="AMD GPU Operator Utility Image"
 LABEL description="The AMD GPU Operator utils image is a utility image used by the AMD GPU Operator. The operator controller employs this image as the container's base layer to automate tasks on target worker nodes."
 
 # Install nsenter from util-linux package
-RUN microdnf install -y util-linux pciutils kmod && \
+RUN microdnf install -y util-linux pciutils kmod tar && \
     cp /usr/bin/nsenter /nsenter && \
     microdnf clean all
 
 ADD LICENSE /licenses/LICENSE
+
+# Install kubectl and oc
+RUN mkdir -p /oc && cd /oc && \
+    curl -SsLO 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-amd64-rhel9-4.19.13.tar.gz' && \
+    tar -xzf openshift-client-linux-amd64-rhel9-4.19.13.tar.gz -C /oc && \
+    cp ./kubectl /usr/local/bin && chmod +x /usr/local/bin/kubectl && \
+    cp ./oc /usr/local/bin && chmod +x /usr/local/bin/oc && \
+    rm -rf /oc
 
 # Set entrypoint to nsenter
 ENTRYPOINT ["/nsenter"]

--- a/tests/e2e/yamls/config/npd/node-problem-detector-rbac.yaml
+++ b/tests/e2e/yamls/config/npd/node-problem-detector-rbac.yaml
@@ -11,10 +11,7 @@ metadata:
   name: node-problem-detector
 rules:
 - apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["pods"]
+  resources: ["nodes", "pods", "services"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["events"]


### PR DESCRIPTION
(cherry picked from commit 242ddb4f37e27a6e61d421469b92881beaf1ba71)

## Motivation

1. Add kubectl and oc to gpu-operator-utils container
2. Currently image used in workflow steps is hard-coded. Make it configurable via device config CR. Re-use CommonConfig.UtilsContainer section to pick the utility container image.
3. Add a new field in RemediationWorkflowSpec to take the value of AGFHC container image.
4. Fix NPD e2e tests rbac yaml

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
