### PR TITLE
[CP 1004][Feature] Add pod UID and framework name in test runner event (#1004)

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -2,12 +2,15 @@
 
 ## GPU Operator v1.4.1 Release Notes
 
-The AMD GPU Operator v1.4.1 release extends platform support to OpenShift v4.19
+The AMD GPU Operator v1.4.1 release extends platform support to OpenShift v4.20
 
 ### Release Highlights
 - **Device-Metrics-Exporter enhancements**
   - **Enhanced Pod and Service Annotations**
     - **Pod Annotations**, **Service Annotations** : Custom annotations can now be applied to exporter pods via the DeviceConfig CRD
+- **Test Runner enhancements**
+  - **Enhanced Test Result Events**
+    - Test runner Kubernetes events now include additional information: pod UID and test framework name (e.g., RVS, AGFHC) as event labels, providing more comprehensive test run information for improved tracking and diagnostics.
 
 ## GPU Operator v1.4.0 Release Notes
 

--- a/docs/test/auto-unhealthy-device-test.md
+++ b/docs/test/auto-unhealthy-device-test.md
@@ -90,6 +90,7 @@ Test runner generated event can be retrieved by filtering the source component: 
     "labels": {
       "testrunner.amd.com/category": "gpu_health_check",
       "testrunner.amd.com/gpu.id.0": "35824",
+      "testrunner.amd.com/framework": "RVS",
       "testrunner.amd.com/gpu.kfd.35824": "0",
       "testrunner.amd.com/hostname": "leto",
       "testrunner.amd.com/recipe": "gst_single",
@@ -191,6 +192,7 @@ in the above example ```35824``` is the GPU's KFD ID reported by amd-smi (in roc
     * ```testrunner.amd.com/recipe``` is the test recipe name.
     * ```testrunner.amd.com/hostname``` is the name of the host where the test happened.
     * ```testrunner.amd.com/gpu.id.X``` shows which GPU was involved and ```X``` is the GPU index number, the value is corresponding GPU KFD ID.
+    * ```testrunner.amd.com/framework``` indicates the test framework used to execute the test.
     * ```testrunner.amd.com/gpu.kfd.Y``` shows which GPU was involved and ```Y``` is the GPU KFD ID, the value is corresponding GPU index number.
 * ```reason``` gives an overall result of the whole test run, it could be ```TestPassed```, ```TestFailed``` or ```TestTimedOut```.
 * ```source``` shows where the event came from, including component name ```amd-test-runner``` and worker node's host name.

--- a/docs/test/manual-test.md
+++ b/docs/test/manual-test.md
@@ -138,6 +138,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID # Use downward API to pass pod UID to test runner container
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NODE_NAME # Use downward API to pass host name to test runner container
           valueFrom:
             fieldRef:
@@ -268,6 +272,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID # Use downward API to pass pod UID to test runner container
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NODE_NAME # Use downward API to pass host name to test runner container
           valueFrom:
             fieldRef:
@@ -433,6 +441,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -623,6 +635,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID # Use downward API to pass pod UID to test runner container
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NODE_NAME # Use downward API to pass host name to test runner container
           valueFrom:
             fieldRef:
@@ -783,6 +799,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID # Use downward API to pass pod UID to test runner container
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NODE_NAME # Use downward API to pass host name to test runner container
           valueFrom:
             fieldRef:

--- a/docs/test/pre-start-job-test.md
+++ b/docs/test/pre-start-job-test.md
@@ -137,6 +137,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID # Use downward API to pass pod UID to test runner container
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NODE_NAME # Use downward API to pass host name to test runner container
           valueFrom:
             fieldRef:

--- a/example/testrunner/manual_test_job.yaml
+++ b/example/testrunner/manual_test_job.yaml
@@ -181,6 +181,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID # Use downward API to pass pod UID to test runner container
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NODE_NAME # Use downward API to pass host name to test runner container
           valueFrom:
             fieldRef:

--- a/example/testrunner/pre_start_job_check.yaml
+++ b/example/testrunner/pre_start_job_check.yaml
@@ -169,6 +169,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_UID # Use downward API to pass pod UID to test runner container
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NODE_NAME # Use downward API to pass host name to test runner container
           valueFrom:
             fieldRef:

--- a/example/testrunner/schedule_test_cronjob.yaml
+++ b/example/testrunner/schedule_test_cronjob.yaml
@@ -176,6 +176,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: NODE_NAME
               valueFrom:
                 fieldRef:

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -234,6 +234,14 @@ func (nl *testRunner) SetTestRunnerAsDesired(ds *appsv1.DaemonSet, devConfig *am
 					},
 				},
 				{
+					Name: "POD_UID",
+					ValueFrom: &v1.EnvVarSource{
+						FieldRef: &v1.ObjectFieldSelector{
+							FieldPath: "metadata.uid",
+						},
+					},
+				},
+				{
 					Name: "NODE_NAME",
 					ValueFrom: &v1.EnvVarSource{
 						FieldRef: &v1.ObjectFieldSelector{

--- a/tests/e2e/testrunner_test.go
+++ b/tests/e2e/testrunner_test.go
@@ -334,10 +334,11 @@ func (s *E2ESuite) verifyTestResultEvts(node, recipe string, devCfg *v1alpha1.De
 	// verify that the test run event got generated
 	logger.Print("Verifying test result event(s)")
 	testEventLabel := map[string]string{
-		"testrunner.amd.com/category": "gpu_health_check",
-		"testrunner.amd.com/trigger":  "auto_unhealthy_gpu_watch",
-		"testrunner.amd.com/recipe":   recipe,
-		"testrunner.amd.com/hostname": node,
+		"testrunner.amd.com/category":  "gpu_health_check",
+		"testrunner.amd.com/trigger":   "auto_unhealthy_gpu_watch",
+		"testrunner.amd.com/recipe":    recipe,
+		"testrunner.amd.com/hostname":  node,
+		"testrunner.amd.com/framework": s.framework,
 	}
 	assert.Eventually(c, func() bool {
 		evts, err := s.clientSet.CoreV1().Events(devCfg.Namespace).List(context.TODO(), metav1.ListOptions{


### PR DESCRIPTION
## Motivation

Add more information to test runner generated test result events:

pod UID
framework name
Those fields are required by OpenShift web console to properly showcase the detailed test run information

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
