### PR TITLE
Add SLES support for AMD gpu-operator

### DIFF
--- a/internal/kmmmodule/dockerfiles/DockerfileTemplate.sles
+++ b/internal/kmmmodule/dockerfiles/DockerfileTemplate.sles
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+#
+# Uses a SUSE built AMD GPU driver image as source, avoiding the need
+# for a SUSEConnect registration key. modules.dep uses relative paths so it is
+# valid for any kernel version in the same codestream (stable kABI).
+#
+# Build args:
+#   KERNEL_FULL_VERSION      - target kernel version, e.g. "6.4.0-150700.53.25-default"
+#   SUSE_PREBUILT_DRIVER_IMG - SUSE-published driver image (built against GA kernel)
+
+ARG SUSE_PREBUILT_DRIVER_IMG
+
+FROM ${SUSE_PREBUILT_DRIVER_IMG} AS driver-source
+
+FROM $$BASEIMG_REGISTRY/bci/bci-micro:$$VERSION
+
+ARG KERNEL_FULL_VERSION
+
+# Relocate modules, kernel tree and depmod metadata from the GA kernel path to
+# the target kernel version path; no depmod re-run needed (relative paths).
+COPY --from=driver-source /opt/lib/modules/ /opt/lib/modules-prebuilt/
+RUN set -euo pipefail; \
+    GA_KERNEL=$(ls /opt/lib/modules-prebuilt/ | head -1); \
+    mkdir -p /opt/lib/modules/${KERNEL_FULL_VERSION}/updates/dkms; \
+    cp /opt/lib/modules-prebuilt/${GA_KERNEL}/updates/dkms/amd* \
+       /opt/lib/modules/${KERNEL_FULL_VERSION}/updates/dkms/; \
+    cp /opt/lib/modules-prebuilt/${GA_KERNEL}/modules.* \
+       /opt/lib/modules/${KERNEL_FULL_VERSION}/; \
+    cp -r /opt/lib/modules-prebuilt/${GA_KERNEL}/kernel \
+          /opt/lib/modules/${KERNEL_FULL_VERSION}/kernel; \
+    rm -rf /opt/lib/modules-prebuilt
+
+RUN mkdir -p /firmwareDir/updates/amdgpu
+COPY --from=driver-source /firmwareDir/updates/amdgpu /firmwareDir/updates/amdgpu

--- a/internal/kmmmodule/kmmmodule.go
+++ b/internal/kmmmodule/kmmmodule.go
@@ -85,6 +85,8 @@ var (
 	dockerfileTemplateCoreOSFromSrcImage string
 	//go:embed dockerfiles/DockerfileTemplate.rpm.coreos
 	dockerfileTemplateCoreOSFromRPM string
+	//go:embed dockerfiles/DockerfileTemplate.sles
+	dockerfileTemplateSLES string
 	//go:embed devdockerfiles/devdockerfile.txt
 	dockerfileDevTemplateUbuntu string
 	//go:embed dockerfiles/DockerfileTemplate.ubuntu.gim
@@ -92,6 +94,14 @@ var (
 	//go:embed dockerfiles/DockerfileTemplate.coreos.gim
 	dockerfileTemplateGIMCoreOS string
 )
+
+// slesCSDPrebuiltDriverImages maps SLES codestream version -> driver version -> prebuilt image.
+// Tag format: sles-<codestream>-<ga_kernel>-<driver_version>
+var slesCSDPrebuiltDriverImages = map[string]map[string]string{
+	"15.7": {
+		"7.0.3": "registry.suse.com/third-party/amd/amdgpu-driver:sles-15.7-7.0.3",
+	},
+}
 
 //go:generate mockgen -source=kmmmodule.go -package=kmmmodule -destination=mock_kmmmodule.go KMMModuleAPI
 type KMMModuleAPI interface {
@@ -290,6 +300,8 @@ func resolveDockerfile(cmName string, devConfig *amdv1alpha1.DeviceConfig) (stri
 				dockerfileTemplate = dockerfileTemplateCoreOSFromSrcImage
 			}
 		}
+	case "sles":
+		dockerfileTemplate = dockerfileTemplateSLES
 	// FIX ME
 	// add the RHEL back when it is fully supported
 	/*case "rhel":
@@ -560,6 +572,25 @@ func getKM(devConfig *amdv1alpha1.DeviceConfig, node v1.Node, inTreeModuleToRemo
 			kmmv1beta1.BuildArg{
 				Name:  "SOURCE_IMAGE_REPO",
 				Value: sourceImageRepo,
+			},
+		)
+	}
+
+	// Inject SUSE_PREBUILT_DRIVER_IMG build arg for SLES nodes.
+	if strings.HasPrefix(osName, "sles-") {
+		csVersion := strings.TrimPrefix(osName, "sles-") // e.g. "15.7"
+		driverVersions, ok := slesCSDPrebuiltDriverImages[csVersion]
+		if !ok {
+			return kmmv1beta1.KernelMapping{}, "", fmt.Errorf("no prebuilt driver image registered for SLES codestream %q", csVersion)
+		}
+		prebuiltImg, ok := driverVersions[driversVersion]
+		if !ok {
+			return kmmv1beta1.KernelMapping{}, "", fmt.Errorf("no prebuilt driver image registered for SLES codestream %q with driver version %q", csVersion, driversVersion)
+		}
+		kmmBuild.BuildArgs = append(kmmBuild.BuildArgs,
+			kmmv1beta1.BuildArg{
+				Name:  "SUSE_PREBUILT_DRIVER_IMG",
+				Value: prebuiltImg,
 			},
 		)
 	}

--- a/internal/kmmmodule/kmmmodule.go
+++ b/internal/kmmmodule/kmmmodule.go
@@ -320,7 +320,11 @@ func resolveDockerfile(cmName string, devConfig *amdv1alpha1.DeviceConfig) (stri
 	// render base image registry
 	baseImageRegistry := defaultBaseImageRegistry
 	if devConfig.Spec.Driver.ImageBuild.BaseImageRegistry != "" {
+		// user-specified registry takes precedence
 		baseImageRegistry = devConfig.Spec.Driver.ImageBuild.BaseImageRegistry
+	} else if osDistro == "sles" {
+		// if OS == "sles", use default image registry as "registry.suse.com"
+		baseImageRegistry = "registry.suse.com"
 	}
 	dockerfileTemplate = strings.Replace(dockerfileTemplate, "$$BASEIMG_REGISTRY", baseImageRegistry, -1)
 	// render driver version

--- a/internal/kmmmodule/kmmmodule.go
+++ b/internal/kmmmodule/kmmmodule.go
@@ -624,6 +624,8 @@ var cmNameMappers = map[string]func(fullImageStr string) string{
 	"rhel":    rhelCMNameMapper,
 	"red hat": rhelCMNameMapper,
 	"redhat":  rhelCMNameMapper,
+	"sles":    slesCMNameMapper,
+	"suse":    slesCMNameMapper,
 }
 
 func rhelCMNameMapper(osImageStr string) string {
@@ -655,6 +657,19 @@ func ubuntuCMNameMapper(osImageStr string) string {
 	versionSplits := strings.Split(version, ".")
 	trimmedVersion := strings.Join(versionSplits[:2], ".")
 	return fmt.Sprintf("%s-%s", os, trimmedVersion)
+}
+
+func slesCMNameMapper(osImageStr string) string {
+	// Example: "SUSE Linux Enterprise Server 15 SP7" -> "sles-15.7"
+	// Example: "suse linux enterprise server 15-sp7" -> "sles-15.7"
+	// Convert to lowercase for consistent matching
+	osImageLower := strings.ToLower(osImageStr)
+	re := regexp.MustCompile(`(\d+)\s*-?\s*sp(\d+)`)
+	matches := re.FindStringSubmatch(osImageLower)
+	if len(matches) >= 3 {
+		return fmt.Sprintf("sles-%s.%s", matches[1], matches[2])
+	}
+	return "sles-" + osImageLower
 }
 
 func GetK8SNodes(ctx context.Context, cli client.Client, labelSelector labels.Selector) (*v1.NodeList, error) {

--- a/internal/kmmmodule/kmmmodule_test.go
+++ b/internal/kmmmodule/kmmmodule_test.go
@@ -732,3 +732,60 @@ var _ = Describe("getKernelMappings", func() {
 		}
 	})
 })
+
+var _ = Describe("resolveDockerfile", func() {
+	It("should use correct default registry when not specified by user", func() {
+		testCases := []struct {
+			cmName           string
+			expectedImageUrl string
+		}{
+			{"ubuntu-22.04", "docker.io/ubuntu:22.04"},
+			{"sles-15.6", "registry.suse.com/bci/bci-micro:15.6"},
+		}
+		for _, tc := range testCases {
+			input := &amdv1alpha1.DeviceConfig{
+				Spec: amdv1alpha1.DeviceConfigSpec{
+					Driver: amdv1alpha1.DriverSpec{},
+				},
+			}
+			dockerfile, err := resolveDockerfile(tc.cmName, input)
+			Expect(err).To(BeNil())
+			Expect(dockerfile).To(ContainSubstring(tc.expectedImageUrl))
+		}
+	})
+	It("should respect user-specified BaseImageRegistry for all OS types", func() {
+		testCases := []struct {
+			cmName           string
+			expectedImageUrl string
+		}{
+			{"ubuntu-22.04", "example-image-registry.com/ubuntu:22.04"},
+			{"sles-15.6", "example-image-registry.com/bci/bci-micro:15.6"},
+		}
+		for _, tc := range testCases {
+			input := &amdv1alpha1.DeviceConfig{
+				Spec: amdv1alpha1.DeviceConfigSpec{
+					Driver: amdv1alpha1.DriverSpec{
+						ImageBuild: amdv1alpha1.ImageBuildSpec{
+							BaseImageRegistry: "example-image-registry.com",
+						},
+					},
+				},
+			}
+			dockerfile, err := resolveDockerfile(tc.cmName, input)
+			Expect(err).To(BeNil())
+			Expect(dockerfile).To(ContainSubstring(tc.expectedImageUrl))
+			Expect(dockerfile).NotTo(ContainSubstring("docker.io"))
+			Expect(dockerfile).NotTo(ContainSubstring("registry.suse.com"))
+		}
+	})
+	It("should return error for unsupported OS", func() {
+		input := &amdv1alpha1.DeviceConfig{
+			Spec: amdv1alpha1.DeviceConfigSpec{
+				Driver: amdv1alpha1.DriverSpec{},
+			},
+		}
+		_, err := resolveDockerfile("unsupported-os", input)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("not supported OS"))
+	})
+})

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -198,6 +198,8 @@ var defaultDriverversionsMappers = map[string]func(fullImageStr string) (string,
 	"red hat": func(f string) (string, error) {
 		return defaultOcDriversVersion, nil
 	},
+	"sles": SLESDefaultDriverVersionsMapper,
+	"suse": SLESDefaultDriverVersionsMapper,
 }
 
 func UbuntuDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
@@ -230,6 +232,21 @@ func UbuntuDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
 		return "6.3.3", nil // due to a known ROCM issue, 6.2 unload + load back may cause system reboot, let's use 6.3.3 as default
 	}
 	return "", fmt.Errorf("unsupported Ubuntu version: %s. Supported versions include 20.04, 22.04 and 24.04", fullImageStr)
+}
+
+var slesSPRegexp = regexp.MustCompile(`15\s*-?\s*sp(\d+)`)
+
+func SLESDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
+	if strings.Contains(fullImageStr, "15") {
+		match := slesSPRegexp.FindStringSubmatch(strings.ToLower(fullImageStr))
+		if len(match) > 1 {
+			spVersion, err := strconv.Atoi(match[1])
+			if err == nil && spVersion >= 7 {
+				return "7.0.3", nil // Latest stable version for SP7+
+			}
+		}
+	}
+	return "", fmt.Errorf("unsupported SLES version: %s. Supported versions include SLES 15 SP7 and above", fullImageStr)
 }
 
 func HasNodeLabelKey(node v1.Node, labelKey string) bool {

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -364,3 +364,50 @@ func TestUbuntuDefaultDriverVersionsMapper(t *testing.T) {
 		})
 	}
 }
+
+func TestSLESDefaultDriverVersionsMapper(t *testing.T) {
+	tests := []struct {
+		name     string
+		osImage  string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "SLES 15 SP7",
+			osImage:  "SUSE Linux Enterprise Server 15 SP7",
+			expected: "7.0.3",
+			wantErr:  false,
+		},
+		{
+			name:     "SLES 15 SP7 with dash format",
+			osImage:  "sles 15-sp7",
+			expected: "7.0.3",
+			wantErr:  false,
+		},
+		{
+			name:    "SLES 15 SP6 unsupported",
+			osImage: "SUSE Linux Enterprise Server 15 SP6",
+			wantErr: true,
+		},
+		{
+			name:    "SLES 15 base unsupported",
+			osImage: "SUSE Linux Enterprise Server 15",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := SLESDefaultDriverVersionsMapper(tt.osImage)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SLESDefaultDriverVersionsMapper() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("SLESDefaultDriverVersionsMapper() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR aim at adding support for SUSE Linux Enterprise Server (SLES) 15 SP7+ to the AMD GPU operator.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- abbdaa825ea3b9531af2f3d0ac55e46c588d6bbe -  add support for detecting SLES nodes and automatically selecting appropriate AMD GPU driver versions
    * add new `slesCMNameMapper` to parse SLES version strings like 'SUSE Linux Enterprise Server 15 SP7' to 'sles-15.7'
    * add `SLESDefaultDriverVersionsMapper` to select driver versions
    * register both 'sles' and 'suse' identifiers in mappers

- 669b888385abb78c783d033bc15c3a6219bf1647 - add SLES Dockerfile template (`DockerfileTemplate.sles`) using prebuilt SUSE AMD GPU Driver image (currently, I've skipped adding the GIM Dockerfile template for SLES, will tackle it once this goes through).
    - also embed the template via go:embed and add SLES case logic 
 
- ~c2dce4489d891c4b389eb90b20718a2f35c2ddef - docs: update example/deviceconfig_example.yaml~ <- dropped

- 017fcb56b2958a44edb29e3056cdd55cd01f8446- use "registry.suse.com" as the default base image registry if OS == "sles"
    * although, use-specified `BaseImageRegistry` still takes precedence 
    * also extend tests in `internal/kmmodule/kmmodule_test.go` to test above changes in `resolveDockerfile` func


## Test Plan

- 13248e773408a24ec5a290af2348a3a3b9fdeac4 - tests: update internal/utils_test.go for added support for SLES 15 SP*

<!-- Explain any relevant testing done to verify this PR. -->


## Test Result

<!-- Briefly summarize test outcomes. -->

- truncated output of `make unit-test` after new added tests 
  ```
  > make unit-test
  ...
  ...
  === RUN   TestSLESDefaultDriverVersionsMapper
  === RUN   TestSLESDefaultDriverVersionsMapper/SLES_15_SP6
  === RUN   TestSLESDefaultDriverVersionsMapper/SLES_15_SP7
  === RUN   TestSLESDefaultDriverVersionsMapper/SLES_15_SP5
  === RUN   TestSLESDefaultDriverVersionsMapper/SLES_15_SP4
  === RUN   TestSLESDefaultDriverVersionsMapper/SLES_15_base
  === RUN   TestSLESDefaultDriverVersionsMapper/SLES_15_with_dash_format
  --- PASS: TestSLESDefaultDriverVersionsMapper (0.00s)
      --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_15_SP6 (0.00s)
      --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_15_SP7 (0.00s)
      --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_15_SP5 (0.00s)
      --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_15_SP4 (0.00s)
      --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_15_base (0.00s)
      --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_15_with_dash_format (0.00s)
  PASS
  coverage: 48.6% of statements
  ok  	github.com/ROCm/gpu-operator/internal	0.019s	coverage: 48.6% of statements
  === RUN   TestAPIs
  Running Suite: Controller Suite - /home/psaggu/work-suse/amd-gpu-operator-work/oct-23-pr/gpu-operator/internal/controllers
  ==========================================================================================================================
  Random Seed: 1761223798
  
  Will run 15 of 15 specs
  •••••••••••••••
  
  Ran 15 of 15 Specs in 0.008 seconds
  SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 0 Skipped
  --- PASS: TestAPIs (0.01s)
  PASS
  coverage: 7.9% of statements
  ok  	github.com/ROCm/gpu-operator/internal/controllers	(cached)	coverage: 7.9% of statements
  === RUN   TestAPIs
  Running Suite: KMMModule Suite - /home/psaggu/work-suse/amd-gpu-operator-work/oct-23-pr/gpu-operator/internal/kmmmodule
  =======================================================================================================================
  Random Seed: 1761223798
  
  Will run 5 of 5 specs
  testing multiple valid homogeneous nodes
  testing multiple valid heterogeneous nodes
  testing multiple valid heterogeneous nodes + one unsupported node
  testing multiple unsupported nodes
  testing empty node list
  •<moduleName>
  <amdgpu>
  •<moduleName>
  <amdgpu>
  •••
  
  Ran 5 of 5 Specs in 0.005 seconds
  SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 0 Skipped
  --- PASS: TestAPIs (0.01s)
  PASS
  coverage: 32.3% of statements
  ok  	github.com/ROCm/gpu-operator/internal/kmmmodule	(cached)	coverage: 32.3% of statements
  
  •••••••••••••••
  
  Ran 15 of 15 Specs in 0.008 seconds
  SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 0 Skipped
  ```

---

- output from tests added 
  
  ```
  ❯ go test ./internal/kmmmodule/... -v -ginkgo.focus="resolveDockerfile" -ginkgo.v
  === RUN   TestAPIs
  Running Suite: KMMModule Suite - /home/psaggu/work-suse/amd-gpu-operator-work/oct-23-pr/gpu-operator/internal/kmmmodule
  =======================================================================================================================
  Random Seed: 1761548380
  
  Will run 3 of 8 specs
  SSSS
  ------------------------------
  resolveDockerfile should use correct default registry when not specified by user
  /home/psaggu/work-suse/amd-gpu-operator-work/oct-23-pr/gpu-operator/internal/kmmmodule/kmmmodule_test.go:683
  • [0.000 seconds]
  ------------------------------
  resolveDockerfile should respect user-specified BaseImageRegistry for all OS types
  /home/psaggu/work-suse/amd-gpu-operator-work/oct-23-pr/gpu-operator/internal/kmmmodule/kmmmodule_test.go:702
  • [0.000 seconds]
  ------------------------------
  resolveDockerfile should return error for unsupported OS
  /home/psaggu/work-suse/amd-gpu-operator-work/oct-23-pr/gpu-operator/internal/kmmmodule/kmmmodule_test.go:727
  • [0.000 seconds]
  ------------------------------
  S
  
  Ran 3 of 8 Specs in 0.000 seconds
  SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 5 Skipped
  --- PASS: TestAPIs (0.00s)
  PASS
  ok  	github.com/ROCm/gpu-operator/internal/kmmmodule	0.022s
  ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
