### PR TITLE
[Feature] Add OpenShift monitoring required RBAC in OLM bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,7 @@ helm-k8s: helmify manifests kustomize clean-helm-k8s gen-kmm-charts-k8s ## Build
 	# Removing OpenShift related rbac from vanilla k8s helm charts
 	rm $(shell pwd)/helm-charts-k8s/templates/kmm-device-plugin-rbac.yaml
 	rm $(shell pwd)/helm-charts-k8s/templates/kmm-module-loader-rbac.yaml
+	rm $(shell pwd)/helm-charts-k8s/templates/prometheus-k8s-rbac.yaml
 	# Patching k8s helm chart kmm subchart
 	cp $(shell pwd)/hack/k8s-patch/k8s-kmm-patch/metadata-patch/*.yaml $(shell pwd)/helm-charts-k8s/charts/kmm/
 	cp $(shell pwd)/hack/k8s-patch/k8s-kmm-patch/template-patch/*.yaml $(shell pwd)/helm-charts-k8s/charts/kmm/templates/

--- a/bundle/manifests/amd-gpu-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/amd-gpu-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/name: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  name: amd-gpu-operator-prometheus-k8s
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/amd-gpu-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/amd-gpu-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/name: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  name: amd-gpu-operator-prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: amd-gpu-operator-prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: AI/Machine Learning,Monitoring
     containerImage: docker.io/rocm/gpu-operator:v1.4.0
-    createdAt: "2025-10-15T21:31:06Z"
+    createdAt: "2025-10-24T01:39:09Z"
     description: |-
       Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
       For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -28,3 +28,5 @@ resources:
   - config_manager_role.yaml
   - config_manager_role_binding.yaml
   - config_manager_service_account.yaml
+  - openshift-monitoring-role.yaml
+  - openshift-monitoring-rolebinding.yaml

--- a/config/rbac/openshift-monitoring-role.yaml
+++ b/config/rbac/openshift-monitoring-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/rbac/openshift-monitoring-rolebinding.yaml
+++ b/config/rbac/openshift-monitoring-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/docs/installation/openshift-olm.md
+++ b/docs/installation/openshift-olm.md
@@ -2,6 +2,10 @@
 
 This guide explains how to deploy the AMD GPU Operator on OpenShift using the Operator Lifecycle Manager (OLM).
 
+```{note}
+For installing AMD GPU Operator in air-gapped OpenShift cluster, please also refer to [OpenShift Air-Gapped Installation](../specialized_networks/airgapped-install-openshift.md)
+```
+
 ## Prerequisites
 
 Before installing the AMD GPU Operator, ensure your OpenShift cluster meets the following requirements:
@@ -312,6 +316,40 @@ oc get pods | grep test-cr
 # Verify GPU resource labels
 oc get node -o json | grep amd.com
 ```
+
+### 4. Enable Cluster Monitoring
+
+In order to enable the OpenShift native cluster monitoring stack to scrape metrics from metrics exporter, please:
+
+* Label the namespace with OpenShift specific cluster monitoring label
+
+For example if AMD GPU Operator was deployed in namespace `openshift-amd-gpu`:
+
+```bash
+oc label namespace openshift-amd-gpu openshift.io/cluster-monitoring="true"
+```
+
+* Enable the metrics exporter and configure the `serviceMonitor` in `DeviceConfig`
+
+For example:
+
+```yaml
+spec:
+  metricsExporter:
+    enable: true
+    prometheus:
+      serviceMonitor:
+        enable: true
+        interval: "60s" # Metrics scrape interval
+        attachMetadata:
+          node: true
+```
+
+After applying this configuration, verify the metrics are being collected:
+
+* Navigate to the OpenShift web console
+* Go to **Observe** → **Targets** to confirm the metrics target is active
+* Go to **Observe** → **Metrics** to query AMD GPU metrics
 
 ## Uninstallation
 

--- a/hack/openshift-patch/template-patch/prometheus-k8s-rbac.yaml
+++ b/hack/openshift-patch/template-patch/prometheus-k8s-rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "helm-charts-openshift.fullname" . }}-prometheus-k8s
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-openshift.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "helm-charts-openshift.fullname" . }}-prometheus-k8s
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-openshift.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "helm-charts-openshift.fullname" . }}-prometheus-k8s'
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/helm-charts-openshift/templates/prometheus-k8s-rbac.yaml
+++ b/helm-charts-openshift/templates/prometheus-k8s-rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "helm-charts-openshift.fullname" . }}-prometheus-k8s
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-openshift.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "helm-charts-openshift.fullname" . }}-prometheus-k8s
+  labels:
+    app.kubernetes.io/component: amd-gpu
+    app.kubernetes.io/part-of: amd-gpu
+  {{- include "helm-charts-openshift.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "helm-charts-openshift.fullname" . }}-prometheus-k8s'
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring


### PR DESCRIPTION
## Motivation

[Collecting metrics with Prometheus](https://rhobs-handbook.netlify.app/products/openshiftmonitoring/collecting_metrics.md/#configuring-prometheus-to-scrape-metrics)  documented the requirements to configure OpenShift cluster monitoring to scrape metrics from other namespace;

1. label the namespace with 
`openshift.io/cluster-monitoring: true`
2. Create the RBAC resources that this PR is trying to add.

3. Create ServiceMonitor/PodMonitor

* Item 1 needs to be documented

* Item 2 needs to be added into OLM bundle

* Item 3 could already got created by the released GPU Operator

## Technical Details

 this PR is adding documentation for Item 1 and adding RBAC resources into OLM bundle for Item 2.

## Test Plan

Bring up a fresh new OpenShift cluster, follow the updated documentation to install NFD, KMM, AMD GPU Operator. Create a `DeviceConfig` to install amdgpu kmod, enable metrics exporter and serviceMonitor. Label the namespace to enable the cluster monitoring on target namespace.

## Test Result

On the OpenShift web console, the Observe page shows active metrics exporter target and users could query AMD GPU metrics on Observe --- Metrics webpage.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
