### PR TITLE
[Fix] Fix several VF PCI device IDs in NFD rule (#1006)

### DIFF
--- a/docs/installation/openshift-olm.md
+++ b/docs/installation/openshift-olm.md
@@ -155,10 +155,11 @@ spec:
                       "75a3", # MI355X
                       "75a0", # MI350X
                       "74a5", # MI325X
+                      "74a2", # MI308X
+                      "74a8", # MI308X-HF
                       "74a0", # MI300A
                       "74a1", # MI300X
                       "74a9", # MI300X-HF
-                      "74bd", # MI300X-HF
                       "740f", # MI210
                       "7408", # MI250X
                       "740c", # MI250/MI250X
@@ -177,8 +178,11 @@ spec:
                       "75b3", # MI355X VF
                       "75b0", # MI350X VF
                       "74b9", # MI325X VF
+                      "74b6", # MI308X VF
+                      "74bc", # MI308X-HF VF
                       "74b5", # MI300X VF
-                      "7410", # MI210 VF
+                      "74bd", # MI300X-HF VF
+                      "7410"  # MI210 VF
                     ]}
 ```
 
@@ -206,15 +210,16 @@ spec:
                   "75a3", # MI355X
                   "75a0", # MI350X
                   "74a5", # MI325X
+                  "74a2", # MI308X
+                  "74a8", # MI308X-HF
                   "74a0", # MI300A
                   "74a1", # MI300X
                   "74a9", # MI300X-HF
-                  "74bd", # MI300X-HF
                   "740f", # MI210
                   "7408", # MI250X
                   "740c", # MI250/MI250X
                   "738c", # MI100
-                  "738e" # MI100
+                  "738e"  # MI100
                 ]}
     - name: amd-vgpu
       labels:
@@ -228,8 +233,11 @@ spec:
                   "75b3", # MI355X VF
                   "75b0", # MI350X VF
                   "74b9", # MI325X VF
+                  "74b6", # MI308X VF
+                  "74bc", # MI308X-HF VF
                   "74b5", # MI300X VF
-                  "7410", # MI210 VF
+                  "74bd", # MI300X-HF VF
+                  "7410"  # MI210 VF
                 ]}
 ```
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -12,6 +12,10 @@ The AMD GPU Operator v1.4.1 release extends platform support to OpenShift v4.20
   - **Enhanced Test Result Events**
     - Test runner Kubernetes events now include additional information: pod UID and test framework name (e.g., RVS, AGFHC) as event labels, providing more comprehensive test run information for improved tracking and diagnostics.
 
+### Fixes
+  1. **Node Feature Discovery rule fix**
+     * Fix the PCI device ID for the Virtual Function (VF) of these GPU: MI308X and MI300X-HF
+
 ## GPU Operator v1.4.0 Release Notes
 
 The AMD GPU Operator v1.4.0 adds MI35X platform support and updates all managed operands to ROCm 7 runtime libraries, aligning the full stack with the ROCm 7 release.

--- a/hack/k8s-patch/template-patch/gpu-nfd-default-rule.yaml
+++ b/hack/k8s-patch/template-patch/gpu-nfd-default-rule.yaml
@@ -27,6 +27,21 @@ spec:
           - feature: pci.device
             matchExpressions:
                 vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["74bd"]} # MI300X HF VF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["74b6"]} # MI308X VF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["74bc"]} # MI308X HF VF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
                 device: {op: In, value: ["74b9"]} # Mi325X VF
       - matchFeatures:
           - feature: pci.device
@@ -78,11 +93,6 @@ spec:
           - feature: pci.device
             matchExpressions:
               vendor: {op: In, value: ["1002"]}
-              device: {op: In, value: ["74b6"]} # MI308X
-      - matchFeatures:
-          - feature: pci.device
-            matchExpressions:
-              vendor: {op: In, value: ["1002"]}
               device: {op: In, value: ["74a8"]} # MI308X HF
       - matchFeatures:
           - feature: pci.device
@@ -99,11 +109,6 @@ spec:
             matchExpressions:
               vendor: {op: In, value: ["1002"]}
               device: {op: In, value: ["74a9"]} # MI300X HF
-      - matchFeatures:
-          - feature: pci.device
-            matchExpressions:
-              vendor: {op: In, value: ["1002"]}
-              device: {op: In, value: ["74bd"]} # MI300X HF
       - matchFeatures:
           - feature: pci.device
             matchExpressions:

--- a/helm-charts-k8s/templates/gpu-nfd-default-rule.yaml
+++ b/helm-charts-k8s/templates/gpu-nfd-default-rule.yaml
@@ -27,6 +27,21 @@ spec:
           - feature: pci.device
             matchExpressions:
                 vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["74bd"]} # MI300X HF VF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["74b6"]} # MI308X VF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
+                device: {op: In, value: ["74bc"]} # MI308X HF VF
+      - matchFeatures:
+          - feature: pci.device
+            matchExpressions:
+                vendor: {op: In, value: ["1002"]}
                 device: {op: In, value: ["74b9"]} # Mi325X VF
       - matchFeatures:
           - feature: pci.device
@@ -78,11 +93,6 @@ spec:
           - feature: pci.device
             matchExpressions:
               vendor: {op: In, value: ["1002"]}
-              device: {op: In, value: ["74b6"]} # MI308X
-      - matchFeatures:
-          - feature: pci.device
-            matchExpressions:
-              vendor: {op: In, value: ["1002"]}
               device: {op: In, value: ["74a8"]} # MI308X HF
       - matchFeatures:
           - feature: pci.device
@@ -99,11 +109,6 @@ spec:
             matchExpressions:
               vendor: {op: In, value: ["1002"]}
               device: {op: In, value: ["74a9"]} # MI300X HF
-      - matchFeatures:
-          - feature: pci.device
-            matchExpressions:
-              vendor: {op: In, value: ["1002"]}
-              device: {op: In, value: ["74bd"]} # MI300X HF
       - matchFeatures:
           - feature: pci.device
             matchExpressions:


### PR DESCRIPTION
## Motivation

Some GPU models VF PCI IDs are incorrect, fixing it in NFD rule.

## Technical Details

This fix is referring MxGPU repo https://github.com/amd/MxGPU-Virtualization/blob/4eb773d0dac245b29a368b96e492a8d245337091/libgv/core/amdgv_marketing_name.c#L30

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
