### PR TITLE
[DOC] Make RVS parallel execution in all test runner example YAML

### DIFF
--- a/docs/test/auto-unhealthy-device-test.md
+++ b/docs/test/auto-unhealthy-device-test.md
@@ -226,7 +226,7 @@ data:
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600,
+                      "TimeoutSeconds": 1200,
                       "Arguments": "--parallel"
                     }
                   ]
@@ -241,7 +241,7 @@ data:
                       "Recipe": "mem",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600,
+                      "TimeoutSeconds": 1200,
                       "Arguments": "--parallel"
                     }
                   ]

--- a/docs/test/manual-test.md
+++ b/docs/test/manual-test.md
@@ -74,7 +74,8 @@ data:
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ]
                 }
@@ -213,7 +214,8 @@ data:
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ]
                 }
@@ -366,7 +368,8 @@ data:
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ]
                 }
@@ -545,7 +548,8 @@ data:
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ]
                 }
@@ -559,7 +563,8 @@ data:
                       "Recipe": "babel",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ]
                 }
@@ -703,7 +708,8 @@ data:
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ]
                 }
@@ -717,7 +723,8 @@ data:
                       "Recipe": "babel",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ]
                 }

--- a/docs/test/pre-start-job-test.md
+++ b/docs/test/pre-start-job-test.md
@@ -79,7 +79,7 @@ data:
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600,
+                      "TimeoutSeconds": 1200,
                       "Arguments": "--parallel"
                     }
                   ]

--- a/example/testrunner/config.json
+++ b/example/testrunner/config.json
@@ -10,7 +10,8 @@
                   "Recipe": "gst_single",
                   "Iterations": 1,
                   "StopOnFailure": true,
-                  "TimeoutSeconds": 600
+                  "TimeoutSeconds": 1200,
+                  "Arguments": "--parallel"
                 }
               ],
 	      "LogsExportConfig": [

--- a/example/testrunner/configmap.yaml
+++ b/example/testrunner/configmap.yaml
@@ -17,7 +17,8 @@ data:
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ],
                   "LogsExportConfig": [

--- a/example/testrunner/manual_test_job.yaml
+++ b/example/testrunner/manual_test_job.yaml
@@ -79,7 +79,8 @@ data: # file name within configmap should be config.json
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ]
                 }

--- a/example/testrunner/pre_start_job_check.yaml
+++ b/example/testrunner/pre_start_job_check.yaml
@@ -79,7 +79,8 @@ data: # file name within configmap should be config.json
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ]
                 }
@@ -93,7 +94,8 @@ data: # file name within configmap should be config.json
                       "Recipe": "mem",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ],
                   "LogsExportConfig": [

--- a/example/testrunner/schedule_test_cronjob.yaml
+++ b/example/testrunner/schedule_test_cronjob.yaml
@@ -79,7 +79,8 @@ data: # file name within configmap should be config.json
                       "Recipe": "gst_single",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ]
                 }
@@ -93,7 +94,8 @@ data: # file name within configmap should be config.json
                       "Recipe": "mem",
                       "Iterations": 1,
                       "StopOnFailure": true,
-                      "TimeoutSeconds": 600
+                      "TimeoutSeconds": 1200,
+                      "Arguments": "--parallel"
                     }
                   ],
                   "LogsExportConfig": [


### PR DESCRIPTION
## Motivation

Make `--parallel` as an option showed up in all RVS test examples, so that when users are doing first try, they would take less time to get the test result.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
