### PR TITLE
[Feature] Add default PrometheusRule in OLM bundle to support OCP COO dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,7 @@ bundle-build: operator-sdk manifests kustomize ## OpenShift Build OLM bundle.
 		     PKG=amd-gpu-operator \
 		     SOURCE_DIR=$(dir $(realpath $(lastword $(MAKEFILE_LIST)))) \
 		     KUBECTL_CMD=${KUBECTL_CMD} ./hack/generate-bundle
+	cp $(shell pwd)/hack/openshift-patch/olm-bundle-patch/*.yaml $(shell pwd)/bundle/manifests/
 	${OPERATOR_SDK} bundle validate ./bundle
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 

--- a/bundle/manifests/amdgpu-accelerator-rule_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/amdgpu-accelerator-rule_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -1,0 +1,45 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: amdgpu-accelerator-rule
+  labels:
+    app: amdgpu-metrics-exporter
+spec:
+  groups:
+  - name: amdgpu.accelerator.metrics
+    interval: 30s
+    rules:
+    - record: accelerator_gpu_utilization
+      expr: '{__name__=~".*gpu_gfx_activity$"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_memory_used_bytes
+      expr: '{__name__=~".*gpu_used_vram$"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_memory_total_bytes
+      expr: '{__name__=~".*gpu_total_vram$"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_power_usage_watts
+      expr: '{__name__=~".*gpu_power_usage$"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_temperature_celsius
+      expr: '{__name__=~".*gpu_junction_temperature$"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_sm_clock_hertz
+      expr: '{__name__=~".*gpu_clock$", clock_type=~"GPU_CLOCK_TYPE_SYSTEM|system"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_memory_clock_hertz
+      expr: '{__name__=~".*gpu_clock$", clock_type=~"GPU_CLOCK_TYPE_MEMORY|memory"}'
+      labels:
+        vendor: "amd"

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -11,6 +11,8 @@ The AMD GPU Operator v1.4.1 release extends platform support to OpenShift v4.20 
     - For Red Hat Enterprise Linux CoreOS (used by OpenShift), OpenShift will download source code and firmware from AMD provided [amdgpu-driver images](https://hub.docker.com/r/rocm/amdgpu-driver) into their [DriverToolKit](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/specialized_hardware_and_driver_enablement/driver-toolkit) and directly build the kernel modules from source code without dependency on lots of RPM packages.
   - **Cluster Monitoring Enablement**
     - The v1.4.1 AMD GPU Operator automatically creates the RBAC resources required by the OpenShift [Cluster Monitoring stack](https://rhobs-handbook.netlify.app/products/openshiftmonitoring/collecting_metrics.md/#configuring-prometheus-to-scrape-metrics). This reduces one manual configuration steps when setting up the OpenShift monitoring stack to scrape metrics from the device metrics exporter.
+  - **Integration with OpenShift Cluster Observability Operator Accelerator Dashboard**
+    - Starting with v1.4.1, the AMD GPU Operator automatically creates a `PrometheusRule` that translates key metrics into formats compatible with the OpenShift Cluster Observability Operator's accelerator dashboard, providing an improved out-of-the-box experience.
 - **Device-Metrics-Exporter Enhancements**
   - **Enhanced Pod and Service Annotations**
     - Custom annotations can now be applied to exporter pods and services via the DeviceConfig CRD, providing greater flexibility in metadata management.

--- a/hack/openshift-patch/olm-bundle-patch/amdgpu-accelerator-rule_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/hack/openshift-patch/olm-bundle-patch/amdgpu-accelerator-rule_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -1,0 +1,45 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: amdgpu-accelerator-rule
+  labels:
+    app: amdgpu-metrics-exporter
+spec:
+  groups:
+  - name: amdgpu.accelerator.metrics
+    interval: 30s
+    rules:
+    - record: accelerator_gpu_utilization
+      expr: '{__name__=~".*gpu_gfx_activity$"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_memory_used_bytes
+      expr: '{__name__=~".*gpu_used_vram$"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_memory_total_bytes
+      expr: '{__name__=~".*gpu_total_vram$"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_power_usage_watts
+      expr: '{__name__=~".*gpu_power_usage$"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_temperature_celsius
+      expr: '{__name__=~".*gpu_junction_temperature$"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_sm_clock_hertz
+      expr: '{__name__=~".*gpu_clock$", clock_type=~"GPU_CLOCK_TYPE_SYSTEM|system"}'
+      labels:
+        vendor: "amd"
+
+    - record: accelerator_memory_clock_hertz
+      expr: '{__name__=~".*gpu_clock$", clock_type=~"GPU_CLOCK_TYPE_MEMORY|memory"}'
+      labels:
+        vendor: "amd"


### PR DESCRIPTION
## Motivation

1. OpenShift provides Cluster Observability Operator (COO) for users to get an overview of the cluster
2. COO has a default accelerator dashboard that show key metrics of the accelerator like usage, power consumption and temperature.
3. RedHat asked to add a default `PrometheusRule` in OLM bundle, so that when AMD GPU Operator was deployed the COO customers would see the metrics show up in their accelerator dashboard with a good out-of-box experience.

## Technical Details

1. Add the new YAML file into manifest folder of OLM bundle so that it will be auto deployed during GPU Operator deployment
2. use open prefix and anchored suffix to match the metrics name, because the device-metrics-exporter support user-defined metrics field prefix, so the metrics field name is not 100% fixed and may come with user-defined prefix.
3. for the clock metrics, use label selector to select specific clock rate, in order to distinguish the stream multiprocessor and memory clock rate.

## Test Plan

Verified on the OpenShift setup

## Test Result

Here is the COO dashboard showing AMD GPU metrics

<img width="1848" height="512" alt="image" src="https://github.com/user-attachments/assets/5e64f196-4dc9-4bf5-8c89-620ce0c7b16a" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
