### PR TITLE
[DOC] do not add toleration to devicePlugin to make it auto-restart a…

### DIFF
--- a/docs/dcm/applying-partition-profiles.rst
+++ b/docs/dcm/applying-partition-profiles.rst
@@ -1,10 +1,13 @@
 GPU Partitioning via DCM
 ========================
 
--  GPU on the node cannot be partitioned on the go, we need to bring down all daemonsets using the GPU resource before partitioning. Hence we need to taint the node and the partition.
+- GPU on the node cannot be partitioned on the go, we need to bring down all daemonsets using the GPU resource before partitioning. Hence we need to taint the node and the partition.
 - DCM pod comes with a toleration
     - `key: amd-dcm , value: up , Operator: Equal, effect: NoExecute `
     - User can specify additional tolerations if required
+- Avoid adding the `amd-dcm` toleration to the operands (`device plugin`, `node labeller`, `metrics exporter`, and `test runner`) daemonsets via the `DeviceConfig` spec. 
+    - This ensures operands restart automatically after partitioning completes, allowing them to detect updated GPU resources.
+    - If operands do not restart automatically, manually restart them after partitioning is complete.
 
 GPU Partitioning Workflow
 -------------------------


### PR DESCRIPTION
## Motivation

Related issue: https://github.com/ROCm/gpu-operator/issues/382
Found a common mis-config that could make device plugin not auto-restart during the DCM GPU partitioning process, document it to notify customers for ensuring the restart of device plugin pod during GPU partitioning process.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
