### PR TITLE
[Fix] Auto assign PROJECT_VERSION to be default operand image tag (#1070)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,13 @@ update-version:
 	sed -i '0,/version:/s|version:.*|version: ${PROJECT_VERSION}|' hack/k8s-patch/metadata-patch/Chart.yaml
 	sed -i -e 's|appVersion:.*$$|appVersion: "${PROJECT_VERSION}"|' hack/openshift-patch/metadata-patch/Chart.yaml
 	sed -i '0,/version:/s|version:.*|version: ${PROJECT_VERSION}|' hack/openshift-patch/metadata-patch/Chart.yaml
+	# updating project version in Dockerfile metadata
+	sed -i 's/release="[^"]*"/release="${PROJECT_VERSION}"/g' Dockerfile internal/utils_container/Dockerfile
+	sed -i 's/version="[^"]*"/version="${PROJECT_VERSION}"/g' Dockerfile internal/utils_container/Dockerfile
+	# updating default image tags in Go source files
+	sed -i 's|defaultConfigManagerImage.*=.*"docker.io/rocm/device-config-manager:[^"]*"|defaultConfigManagerImage = "docker.io/rocm/device-config-manager:${PROJECT_VERSION}"|' internal/configmanager/configmanager.go
+	sed -i 's|defaultMetricsExporterImage.*=.*"docker.io/rocm/device-metrics-exporter:[^"]*"|defaultMetricsExporterImage = "docker.io/rocm/device-metrics-exporter:${PROJECT_VERSION}"|' internal/metricsexporter/metricsexporter.go
+	sed -i 's|defaultTestRunnerImage.*=.*"docker.io/rocm/test-runner:[^"]*"|defaultTestRunnerImage = "docker.io/rocm/test-runner:${PROJECT_VERSION}"|' internal/testrunner/testrunner.go
 
 .PHONY: manifests
 manifests: controller-gen update-registry update-version ## Generate ClusterRole and CustomResourceDefinition objects.

--- a/internal/configmanager/configmanager.go
+++ b/internal/configmanager/configmanager.go
@@ -51,7 +51,7 @@ import (
 
 const (
 	// TODO: determine where to host the config manager image and put the registry URL here
-	defaultConfigManagerImage = "docker.io/rocm/device-config-manager:v1.4.0"
+	defaultConfigManagerImage = "docker.io/rocm/device-config-manager:v1.4.1"
 	ConfigManagerName         = "device-config-manager"
 	defaultSAName             = "amd-gpu-operator-config-manager"
 	defaultInitContainerImage = "busybox:1.36"

--- a/internal/metricsexporter/metricsexporter.go
+++ b/internal/metricsexporter/metricsexporter.go
@@ -53,7 +53,7 @@ import (
 )
 
 const (
-	defaultMetricsExporterImage       = "docker.io/rocm/device-metrics-exporter:v1.4.0"
+	defaultMetricsExporterImage       = "docker.io/rocm/device-metrics-exporter:v1.4.1"
 	defaultKubeRbacProxyImage         = "quay.io/brancz/kube-rbac-proxy:v0.18.1"
 	defaultInitContainerImage         = "busybox:1.36"
 	servicePort                 int32 = 5000

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -52,7 +52,7 @@ import (
 
 const (
 	// TODO: determine where to host the test runner image and put the registry URL here
-	defaultTestRunnerImage       = "docker.io/rocm/test-runner:v1.4.0"
+	defaultTestRunnerImage       = "docker.io/rocm/test-runner:v1.4.1"
 	defaultInitContainerImage    = "busybox:1.36"
 	TestRunnerName               = "test-runner"
 	defaultSAName                = "amd-gpu-operator-test-runner"


### PR DESCRIPTION
## Motivation

Automatically assign value to the default operand image tag, make it synced with `PROJECT_VERSION`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
