### PR TITLE
[Build] update helm lint command to match with helm v3/v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ helm-k8s: helmify manifests kustomize clean-helm-k8s gen-kmm-charts-k8s ## Build
 	mkdir -p $(shell pwd)/helm-charts-k8s/charts/remediation/templates
 	cp $(shell pwd)/hack/k8s-patch/k8s-remediation-patch/metadata-patch/*.yaml $(shell pwd)/helm-charts-k8s/charts/remediation/
 	cp $(shell pwd)/hack/k8s-patch/k8s-remediation-patch/template-patch/*.yaml $(shell pwd)/helm-charts-k8s/charts/remediation/templates/
-	cd $(shell pwd)/helm-charts-k8s; helm dependency update; helm lint; cd ..;
+	cd $(shell pwd)/helm-charts-k8s; helm dependency update; helm lint .; cd ..;
 	mkdir $(shell pwd)/helm-charts-k8s/crds
 	echo "moving crd yaml files to crds folder"
 	@for file in $(CRD_YAML_FILES); do \
@@ -341,7 +341,7 @@ helm-k8s: helmify manifests kustomize clean-helm-k8s gen-kmm-charts-k8s ## Build
 	rm $(shell pwd)/helm-charts-k8s/templates/*crd.yaml
 	$(MAKE) helm-docs
 	echo "dependency update, lint and pack charts"
-	cd $(shell pwd)/helm-charts-k8s; helm dependency update; helm lint; cd ..; helm package helm-charts-k8s/ --destination ./helm-charts-k8s
+	cd $(shell pwd)/helm-charts-k8s; helm dependency update; helm lint .; cd ..; helm package helm-charts-k8s/ --destination ./helm-charts-k8s
 	mv $(shell pwd)/helm-charts-k8s/gpu-operator-charts-$(PROJECT_VERSION).tgz $(shell pwd)/helm-charts-k8s/gpu-operator-helm-k8s-$(PROJECT_VERSION).tgz
 
 .PHONY: helm-openshift
@@ -361,7 +361,7 @@ helm-openshift: helmify manifests kustomize clean-helm-openshift gen-nfd-charts-
 	rm $(shell pwd)/helm-charts-openshift/charts/kmm/templates/device-plugin-rbac.yaml
 	# opeartor already has module-loader rbac yaml, removing the redundant rbac yaml from subchart
 	rm $(shell pwd)/helm-charts-openshift/charts/kmm/templates/module-loader-rbac.yaml
-	cd $(shell pwd)/helm-charts-openshift; helm dependency update; helm lint; cd ..;
+	cd $(shell pwd)/helm-charts-openshift; helm dependency update; helm lint .; cd ..;
 	mkdir $(shell pwd)/helm-charts-openshift/crds
 	echo "moving crd yaml files to crds folder"
 	@for file in $(CRD_YAML_FILES); do \
@@ -369,7 +369,7 @@ helm-openshift: helmify manifests kustomize clean-helm-openshift gen-nfd-charts-
 	done
 	rm $(shell pwd)/helm-charts-openshift/templates/*crd.yaml
 	echo "dependency update, lint and pack charts"
-	cd $(shell pwd)/helm-charts-openshift; helm dependency update; helm lint; cd ..; helm package helm-charts-openshift/ --destination ./helm-charts-openshift
+	cd $(shell pwd)/helm-charts-openshift; helm dependency update; helm lint .; cd ..; helm package helm-charts-openshift/ --destination ./helm-charts-openshift
 	mv $(shell pwd)/helm-charts-openshift/gpu-operator-charts-$(PROJECT_VERSION).tgz $(shell pwd)/helm-charts-openshift/gpu-operator-helm-openshift-$(PROJECT_VERSION).tgz
 
 .PHONY: bundle-build


### PR DESCRIPTION
## Motivation

The latest helm v4 no longer support `helm lint` without a given path, we have to add `.` to make it apply to the helm chart in the current directory.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
