### PR TITLE
[Feature] Add minimal AlmaLinux support (#53)

### DIFF
--- a/internal/kmmmodule/kmmmodule.go
+++ b/internal/kmmmodule/kmmmodule.go
@@ -280,6 +280,9 @@ func resolveDockerfile(cmName string, devConfig *amdv1alpha1.DeviceConfig) (stri
 				dockerfileTemplate = dockerfileTemplateCoreOSFromSrcImage
 			}
 		}
+       case "almalinux":
+	// change when Alma would be fully supported
+		dockerfileTemplate= dockerfileTemplateCoreOSFromSrcImage
 	// FIX ME
 	// add the RHEL back when it is fully supported
 	/*case "rhel":
@@ -779,6 +782,7 @@ var cmNameMappers = map[string]func(fullImageStr string) string{
 	"rhel":    rhelCMNameMapper,
 	"red hat": rhelCMNameMapper,
 	"redhat":  rhelCMNameMapper,
+	"almalinux": almaCMNameMapper,
 }
 
 func rhelCMNameMapper(osImageStr string) string {
@@ -810,6 +814,15 @@ func ubuntuCMNameMapper(osImageStr string) string {
 	versionSplits := strings.Split(version, ".")
 	trimmedVersion := strings.Join(versionSplits[:2], ".")
 	return fmt.Sprintf("%s-%s", os, trimmedVersion)
+}
+
+func almaCMNameMapper(osImageStr string) string {
+       re := regexp.MustCompile(`(\d+\.\d+)`)
+       matches := re.FindStringSubmatch(osImageStr)
+       if len(matches) > 1 {
+               return fmt.Sprintf("%s-%s", "almalinux", matches[1])
+       }
+       return "almalinux-" + osImageStr
 }
 
 func GetK8SNodes(ctx context.Context, cli client.Client, labelSelector labels.Selector) (*v1.NodeList, error) {


### PR DESCRIPTION
## Motivation

This PR adds minimal AlmaLinux support, addressing errors like the one described here (https://github.com/ROCm/gpu-operator/issues/53): 

err: OS: almalinux 8.10 (cerulean leopard) not supported. Should be one of [red hat redhat ubuntu coreos rhel] 


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

This PR adds an `almaCMNameMapper` method, allowing the GPU operator to run on AlmaLinux nodes.

This PR does not add full support for AlmaLinux (i.e. providing the template dockerfiles), it functions in the 2 cases where we use the inbox AMD drivers or have external builds of the driver image.


<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

We have tested this on AlmaLinux 9.5 as well as AlmaLinux 10.1 successfuly with an external driver container build (30.20) as well as the inbox drivers. Please do let me know if you would like me to add additional tests.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

The GPU operator exposes the AMD GPUs as expected on nodes running AlmaLinux 9.5 as well as AlmaLinux 10.1.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
