### PR TITLE
[Documentation] Update OpenShift (OLM) installation instruction to include "useSourceImage" for example DeviceConfig

### DIFF
--- a/docs/installation/openshift-olm.md
+++ b/docs/installation/openshift-olm.md
@@ -418,6 +418,8 @@ metadata:
 spec:
   driver:
     enable: true
+    # Build the driver from source code image inside of the KMM workflow
+    useSourceImage: true
     image: image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/amdgpu_kmod
     # NOTE: Starting from ROCm 7.1 the amdgpu version is using new versioning schema
     # please refer to https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/user-kernel-space-compat-matrix.html

--- a/docs/specialized_networks/airgapped-install-openshift.md
+++ b/docs/specialized_networks/airgapped-install-openshift.md
@@ -179,7 +179,7 @@ spec:
     # For OpenShift, set useSourceImage to true 
     # to enable building driver from source code image in air-gapped environment
     useSourceImage: true
-    version: "7.0"
+    version: "30.20.1"
   devicePlugin:
     enableNodeLabeller: true
   metricsExporter:


### PR DESCRIPTION
## Motivation
The OpenShift (OCP) installation docs should instruct users to enable `.spec.driver.useSourceImage` in the `DeviceConfig` to ensure that is works within the fully supported workflow of OpenShift for KMM builds on both connected and airgapped environments. 

Additionally is updates the Airgapped documentation to sync the example `DeviceConfig`  driver version with the same workflow for OpenShift (OLM) docs

## Technical Details
Update documentation to recommend `useSourceImage` for all OCP installation methods

## Test Plan
Test by including `.spec.driver.useSourceImage: true` in all gpu-operator deployments on OpenShift


## Test Result
Successful build and deployment of the `amdgpu` driver in connected and airgapped environments

## Submission Checklist

- [ x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
