### PR TITLE
[Fix] Correct misspellings across source and test files

### DIFF
--- a/api/v1alpha1/deviceconfig_types.go
+++ b/api/v1alpha1/deviceconfig_types.go
@@ -878,7 +878,7 @@ type TestRunnerSpec struct {
 	// +optional
 	ImageRegistrySecret *v1.LocalObjectReference `json:"imageRegistrySecret,omitempty"`
 
-	// config map to customize the config for test runner, if not specified default test config will be aplied
+	// config map to customize the config for test runner, if not specified default test config will be applied
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret",xDescriptors={"urn:alm:descriptor:com.amd.deviceconfigs:configmap"}
 	// +optional
 	Config *v1.LocalObjectReference `json:"config,omitempty"`

--- a/api/v1alpha1/deviceconfig_types.go
+++ b/api/v1alpha1/deviceconfig_types.go
@@ -920,7 +920,7 @@ type TestRunnerSpec struct {
 	// +optional
 	ImageRegistrySecret *v1.LocalObjectReference `json:"imageRegistrySecret,omitempty"`
 
-	// config map to customize the config for test runner, if not specified default test config will be aplied
+	// config map to customize the config for test runner, if not specified default test config will be applied
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret",xDescriptors={"urn:alm:descriptor:com.amd.deviceconfigs:configmap"}
 	// +optional
 	Config *v1.LocalObjectReference `json:"config,omitempty"`

--- a/internal/controllers/device_config_reconciler.go
+++ b/internal/controllers/device_config_reconciler.go
@@ -992,7 +992,7 @@ func (dcrh *deviceConfigReconcilerHelper) finalizeDeviceConfig(ctx context.Conte
 				}
 			} else {
 				// driver disabled mode won't have KMM CR created
-				// but it still requries the removal of node labels
+				// but it still requires the removal of node labels
 				if err := dcrh.updateNodeLabels(ctx, devConfig, nodes, true); err != nil {
 					logger.Error(err, "failed to update node labels")
 				}
@@ -1267,7 +1267,7 @@ func (dcrh *deviceConfigReconcilerHelper) handleNodeLabeller(ctx context.Context
 		if err := dcrh.updateNodeLabels(ctx, devConfig, nodes, false); err != nil {
 			logger.Error(err, "failed to remove node labeller's labels when node labeller is disabled")
 		}
-		logger.Info("skip handling node labeller as it is disbaled", "namespace", devConfig.Namespace, "name", devConfig.Name)
+		logger.Info("skip handling node labeller as it is disabled", "namespace", devConfig.Namespace, "name", devConfig.Name)
 		return nil
 	}
 

--- a/internal/controllers/device_config_reconciler.go
+++ b/internal/controllers/device_config_reconciler.go
@@ -1009,7 +1009,7 @@ func (dcrh *deviceConfigReconcilerHelper) finalizeDeviceConfig(ctx context.Conte
 				}
 			} else {
 				// driver disabled mode won't have KMM CR created
-				// but it still requries the removal of node labels
+				// but it still requires the removal of node labels
 				if err := dcrh.updateNodeLabels(ctx, devConfig, nodes, true); err != nil {
 					logger.Error(err, "failed to update node labels")
 				}
@@ -1351,7 +1351,7 @@ func (dcrh *deviceConfigReconcilerHelper) handleNodeLabeller(ctx context.Context
 		if err := dcrh.updateNodeLabels(ctx, devConfig, nodes, false); err != nil {
 			logger.Error(err, "failed to remove node labeller's labels when node labeller is disabled")
 		}
-		logger.Info("skip handling node labeller as it is disbaled", "namespace", devConfig.Namespace, "name", devConfig.Name)
+		logger.Info("skip handling node labeller as it is disabled", "namespace", devConfig.Namespace, "name", devConfig.Name)
 		return nil
 	}
 

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -237,7 +237,7 @@ func TestShouldUseKMM(t *testing.T) {
 			Expect: false,
 		},
 		{
-			Description: "enbale driver management with container driver type",
+			Description: "enable driver management with container driver type",
 			DevConfig: &v1alpha1.DeviceConfig{
 				Spec: v1alpha1.DeviceConfigSpec{
 					Driver: v1alpha1.DriverSpec{
@@ -249,7 +249,7 @@ func TestShouldUseKMM(t *testing.T) {
 			Expect: true,
 		},
 		{
-			Description: "enbale driver management with vf-passthrough driver type",
+			Description: "enable driver management with vf-passthrough driver type",
 			DevConfig: &v1alpha1.DeviceConfig{
 				Spec: v1alpha1.DeviceConfigSpec{
 					Driver: v1alpha1.DriverSpec{
@@ -261,7 +261,7 @@ func TestShouldUseKMM(t *testing.T) {
 			Expect: true,
 		},
 		{
-			Description: "enbale driver management with pf-passthrough driver type",
+			Description: "enable driver management with pf-passthrough driver type",
 			DevConfig: &v1alpha1.DeviceConfig{
 				Spec: v1alpha1.DeviceConfigSpec{
 					Driver: v1alpha1.DriverSpec{

--- a/tests/e2e/cluster_test.go
+++ b/tests/e2e/cluster_test.go
@@ -1195,7 +1195,7 @@ func (s *E2ESuite) TestDeploymentWithPreInstalledKMMAndNFD(c *C) {
 	}
 	utils.RunCommand(kmmInstallCommand)
 
-	logger.Infof("Deploying GPU opertor without NFD and KMM Operator")
+	logger.Infof("Deploying GPU operator without NFD and KMM Operator")
 	// Deploy GPU operator. Skip NFD and KMM
 	utils.RunCommand(deployWithoutNFDKMMCommand)
 

--- a/tests/e2e/exporter_test.go
+++ b/tests/e2e/exporter_test.go
@@ -373,7 +373,7 @@ func (s *E2ESuite) TestHealthCheckFeature(c *C) {
 			LabelSelector: labels.SelectorFromSet(rocmLabel).String(),
 		})
 		if err != nil {
-			logger.Printf("Error occured when trying to get the pod. Error: %v", err)
+			logger.Printf("Error occurred when trying to get the pod. Error: %v", err)
 			return false
 		}
 		if pods == nil || len(pods.Items) == 0 {
@@ -409,7 +409,7 @@ func (s *E2ESuite) TestHealthCheckFeature(c *C) {
 			LabelSelector: labels.SelectorFromSet(rocmLabel).String(),
 		})
 		if err != nil {
-			logger.Printf("Error occured when trying to get the pod. Error: %v", err)
+			logger.Printf("Error occurred when trying to get the pod. Error: %v", err)
 			return false
 		}
 		if pods == nil || len(pods.Items) == 0 {
@@ -443,7 +443,7 @@ func (s *E2ESuite) TestHealthCheckFeature(c *C) {
 			LabelSelector: labels.SelectorFromSet(rocmLabel).String(),
 		})
 		if err != nil {
-			logger.Printf("Error occured when trying to get the pod. Error: %v", err)
+			logger.Printf("Error occurred when trying to get the pod. Error: %v", err)
 			return false
 		}
 		if pods == nil || len(pods.Items) == 0 {


### PR DESCRIPTION
## Summary
- Fix 10 misspellings found by the `misspell` linter across 5 files:
  - `occured` → `occurred` (3 instances in `tests/e2e/exporter_test.go`)
  - `requries` → `requires` (`internal/controllers/device_config_reconciler.go`)
  - `disbaled` → `disabled` (`internal/controllers/device_config_reconciler.go`)
  - `aplied` → `applied` (`api/v1alpha1/deviceconfig_types.go`)
  - `enbale` → `enable` (3 instances in `internal/utils_test.go`)
  - `opertor` → `operator` (`tests/e2e/cluster_test.go`)

Signed-off-by: Leonardo Ochoa-Aday <lochoa@redhat.com>