### PR TITLE
Remove KubeVirt and Slurm sections from doc index

### DIFF
--- a/docs/sphinx/_toc.yml
+++ b/docs/sphinx/_toc.yml
@@ -64,17 +64,11 @@ subtrees:
       - file: dcm/device-config-manager-configmap
       - file: dcm/applying-partition-profiles
       - file: dcm/systemd_integration
-  - caption: KubeVirt
-    entries:
-      - file: kubevirt/kubevirt
   - caption: Specialized Networks
     entries:
       - file: specialized_networks/airgapped-install
       - file: specialized_networks/airgapped-install-openshift
       - file: specialized_networks/http-proxy
-  - caption: Slurm on Kubernetes
-    entries:
-      - file: slinky/slinky-example
   - caption: Node Problem Detector
     entries:
       - file: npd/node-problem-detector

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -64,17 +64,11 @@ subtrees:
       - file: dcm/device-config-manager-configmap
       - file: dcm/applying-partition-profiles
       - file: dcm/systemd_integration
-  - caption: KubeVirt
-    entries:
-      - file: kubevirt/kubevirt
   - caption: Specialized Networks
     entries:
       - file: specialized_networks/airgapped-install
       - file: specialized_networks/airgapped-install-openshift
       - file: specialized_networks/http-proxy
-  - caption: Slurm on Kubernetes
-    entries:
-      - file: slinky/slinky-example
   - caption: Node Problem Detector
     entries:
       - file: npd/node-problem-detector


### PR DESCRIPTION
## Summary
- Remove KubeVirt and Slurm on Kubernetes sections from the Sphinx documentation index (`_toc.yml` and `_toc.yml.in`)

## Test plan
- [x] Verify documentation builds without the removed sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)