### PR TITLE
docs: add Kubernetes 1.35 to OS/platform support matrix (#1460)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,17 +41,17 @@ Below is a matrix of supported Operating systems and the corresponding Kubernete
   <tbody>
     <tr style="background-color: white; color: black;">
       <td style="background-color: #2c2c2c; color: white; border: 1px solid grey;">Ubuntu 22.04 LTS</td>
-      <td style="border: 1px solid grey;">1.29-1.34</td>
+      <td style="border: 1px solid grey;">1.29-1.35</td>
       <td style="border: 1px solid grey;"></td>
     </tr>
     <tr style="background-color: lightgrey; color: black;">
       <td style="background-color: #2c2c2c; color: white; border: 1px solid grey;">Ubuntu 24.04 LTS</td>
-      <td style="border: 1px solid grey;">1.29-1.34</td>
+      <td style="border: 1px solid grey;">1.29-1.35</td>
       <td style="border: 1px solid grey;"></td>
     </tr>
     <tr style="background-color: lightgrey; color: black;">
       <td style="background-color: #2c2c2c; color: white; border: 1px solid grey;">Debian 12</td>
-      <td style="border: 1px solid grey;">1.29-1.34 (driver management not supported)</td>
+      <td style="border: 1px solid grey;">1.29-1.35 (driver management not supported)</td>
       <td style="border: 1px solid grey;"></td>
     </tr>
     <tr style="background-color: white; color: black;">

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -183,7 +183,7 @@ The AMD GPU Operator v1.4.0 adds MI35X platform support and updates all managed 
   
 ### Platform Support
 
-- Validated for vanilla kubernetes 1.32, 1.33
+- Validated for vanilla kubernetes 1.32, 1.33, 1.34, 1.35
 
 ### Fixes
 


### PR DESCRIPTION
Update support matrix in index.md and installation prerequisites to reflect validated K8s range 1.29-1.35 (previously showed 1.29-1.34).

CP of https://github.com/pensando/gpu-operator/pull/1461

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
