### PR TITLE
Add SLES 16.0 support and extend SLES 15 SP7 driver versions

### DIFF
--- a/internal/conditions/deviceconfig.go
+++ b/internal/conditions/deviceconfig.go
@@ -35,6 +35,8 @@ const (
 	ErrorStatus = "Error"
 	// ReadyStatus represents operator in ready and healthy state
 	ReadyStatus = "OperatorReady"
+	// NoMatchingNodes indicates no cluster nodes match the DeviceConfig selector
+	NoMatchingNodes = "NoMatchingNodes"
 )
 
 type ConditionManager struct{}

--- a/internal/controllers/device_config_reconciler.go
+++ b/internal/controllers/device_config_reconciler.go
@@ -280,6 +280,17 @@ func (r *DeviceConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return res, fmt.Errorf("validation failed for DeviceConfig %s: %v", req.NamespacedName, result)
 	}
 
+	if len(nodes.Items) == 0 {
+		msg := fmt.Sprintf("no nodes found matching selector %s; verify node labels or check that NFD has labeled the GPU nodes", labels.Set(devConfig.Spec.Selector).String())
+		if errSet := r.helper.setCondition(ctx, conditions.ConditionTypeError, devConfig, metav1.ConditionTrue, conditions.NoMatchingNodes, msg); errSet != nil {
+			logger.Error(fmt.Errorf("Failed to set error condition: %v", errSet), "")
+		}
+		if errSet := r.helper.setCondition(ctx, conditions.ConditionTypeReady, devConfig, metav1.ConditionFalse, conditions.ReadyStatus, ""); errSet != nil {
+			logger.Error(fmt.Errorf("Failed to set ready condition: %v", errSet), "")
+		}
+		return ctrl.Result{}, nil
+	}
+
 	err = r.helper.setFinalizer(ctx, devConfig)
 	if err != nil {
 		return res, fmt.Errorf("failed to set finalizer for DeviceConfig %s: %v", req.NamespacedName, err)

--- a/internal/controllers/device_config_reconciler.go
+++ b/internal/controllers/device_config_reconciler.go
@@ -285,7 +285,7 @@ func (r *DeviceConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if errSet := r.helper.setCondition(ctx, conditions.ConditionTypeError, devConfig, metav1.ConditionTrue, conditions.NoMatchingNodes, msg); errSet != nil {
 			logger.Error(fmt.Errorf("Failed to set error condition: %v", errSet), "")
 		}
-		if errSet := r.helper.setCondition(ctx, conditions.ConditionTypeReady, devConfig, metav1.ConditionFalse, conditions.ReadyStatus, ""); errSet != nil {
+		if errSet := r.helper.setCondition(ctx, conditions.ConditionTypeReady, devConfig, metav1.ConditionFalse, conditions.NoMatchingNodes, msg); errSet != nil {
 			logger.Error(fmt.Errorf("Failed to set ready condition: %v", errSet), "")
 		}
 		return ctrl.Result{}, nil

--- a/internal/kmmmodule/kmmmodule.go
+++ b/internal/kmmmodule/kmmmodule.go
@@ -708,21 +708,20 @@ func ubuntuCMNameMapper(osImageStr string) string {
 	return fmt.Sprintf("%s-%s", os, trimmedVersion)
 }
 
+var slesSPRegexp = regexp.MustCompile(`(\d+)\s*-?\s*sp(\d+)`)
+var slesMajorMinorRegexp = regexp.MustCompile(`(\d+)\.(\d+)`)
+
 func slesCMNameMapper(osImageStr string) string {
 	// Example: "SUSE Linux Enterprise Server 15 SP7" -> "sles-15.7"
 	// Example: "suse linux enterprise server 15-sp7" -> "sles-15.7"
 	// Example: "SUSE Linux Enterprise Server 16.0" -> "sles-16.0"
 	osImageLower := strings.ToLower(osImageStr)
 
-	// SP-style notation (e.g. "15 SP7" or "15-sp7")
-	reSP := regexp.MustCompile(`(\d+)\s*-?\s*sp(\d+)`)
-	if matches := reSP.FindStringSubmatch(osImageLower); len(matches) >= 3 {
+	if matches := slesSPRegexp.FindStringSubmatch(osImageLower); len(matches) >= 3 {
 		return fmt.Sprintf("sles-%s.%s", matches[1], matches[2])
 	}
 
-	// major.minor notation (e.g. "16.0")
-	reMajorMinor := regexp.MustCompile(`(\d+)\.(\d+)`)
-	if matches := reMajorMinor.FindStringSubmatch(osImageLower); len(matches) >= 3 {
+	if matches := slesMajorMinorRegexp.FindStringSubmatch(osImageLower); len(matches) >= 3 {
 		return fmt.Sprintf("sles-%s.%s", matches[1], matches[2])
 	}
 

--- a/internal/kmmmodule/kmmmodule.go
+++ b/internal/kmmmodule/kmmmodule.go
@@ -95,12 +95,26 @@ var (
 	dockerfileTemplateGIMCoreOS string
 )
 
-// slesCSDPrebuiltDriverImages maps SLES codestream version -> driver version -> prebuilt image.
-// Tag format: sles-<codestream>-<ga_kernel>-<driver_version>
-var slesCSDPrebuiltDriverImages = map[string]map[string]string{
-	"15.7": {
-		"7.0.3": "registry.suse.com/third-party/amd/amdgpu-driver:sles-15.7-7.0.3",
-	},
+const slesPrebuiltDriverImageRepo = "registry.suse.com/third-party/amd/amdgpu-driver"
+
+// slesCSDGAKernel maps SLES codestream -> GA kernel version used in prebuilt image tags.
+var slesCSDGAKernel = map[string]string{
+	"15.7": "6.4.0-150700.51",
+}
+
+// slesPrebuiltDriverImage returns the full prebuilt image reference.
+func slesPrebuiltDriverImage(codestream, driverVersion string) (string, bool) {
+	gaKernel, ok := slesCSDGAKernel[codestream]
+	if !ok {
+		return "", false
+	}
+	for _, v := range utils.SlesCSDDriverVersions[codestream] {
+		if v == driverVersion {
+			tag := fmt.Sprintf("sles-%s-%s-default-%s", codestream, gaKernel, driverVersion)
+			return slesPrebuiltDriverImageRepo + ":" + tag, true
+		}
+	}
+	return "", false
 }
 
 //go:generate mockgen -source=kmmmodule.go -package=kmmmodule -destination=mock_kmmmodule.go KMMModuleAPI
@@ -583,11 +597,10 @@ func getKM(devConfig *amdv1alpha1.DeviceConfig, node v1.Node, inTreeModuleToRemo
 	// Inject SUSE_PREBUILT_DRIVER_IMG build arg for SLES nodes.
 	if strings.HasPrefix(osName, "sles-") {
 		csVersion := strings.TrimPrefix(osName, "sles-") // e.g. "15.7"
-		driverVersions, ok := slesCSDPrebuiltDriverImages[csVersion]
-		if !ok {
+		if _, ok := slesCSDGAKernel[csVersion]; !ok {
 			return kmmv1beta1.KernelMapping{}, "", fmt.Errorf("no prebuilt driver image registered for SLES codestream %q", csVersion)
 		}
-		prebuiltImg, ok := driverVersions[driversVersion]
+		prebuiltImg, ok := slesPrebuiltDriverImage(csVersion, driversVersion)
 		if !ok {
 			return kmmv1beta1.KernelMapping{}, "", fmt.Errorf("no prebuilt driver image registered for SLES codestream %q with driver version %q", csVersion, driversVersion)
 		}
@@ -697,13 +710,15 @@ func ubuntuCMNameMapper(osImageStr string) string {
 func slesCMNameMapper(osImageStr string) string {
 	// Example: "SUSE Linux Enterprise Server 15 SP7" -> "sles-15.7"
 	// Example: "suse linux enterprise server 15-sp7" -> "sles-15.7"
-	// Convert to lowercase for consistent matching
+	// Example: "SUSE Linux Enterprise Server 16.0" -> "sles-16.0"
 	osImageLower := strings.ToLower(osImageStr)
-	re := regexp.MustCompile(`(\d+)\s*-?\s*sp(\d+)`)
-	matches := re.FindStringSubmatch(osImageLower)
-	if len(matches) >= 3 {
+
+	// SP-style notation (e.g. "15 SP7" or "15-sp7")
+	reSP := regexp.MustCompile(`(\d+)\s*-?\s*sp(\d+)`)
+	if matches := reSP.FindStringSubmatch(osImageLower); len(matches) >= 3 {
 		return fmt.Sprintf("sles-%s.%s", matches[1], matches[2])
 	}
+
 	return "sles-" + osImageLower
 }
 

--- a/internal/kmmmodule/kmmmodule.go
+++ b/internal/kmmmodule/kmmmodule.go
@@ -100,6 +100,7 @@ const slesPrebuiltDriverImageRepo = "registry.suse.com/third-party/amd/amdgpu-dr
 // slesCSDGAKernel maps SLES codestream -> GA kernel version used in prebuilt image tags.
 var slesCSDGAKernel = map[string]string{
 	"15.7": "6.4.0-150700.51",
+	"16.0": "6.12.0-160000.5",
 }
 
 // slesPrebuiltDriverImage returns the full prebuilt image reference.
@@ -716,6 +717,12 @@ func slesCMNameMapper(osImageStr string) string {
 	// SP-style notation (e.g. "15 SP7" or "15-sp7")
 	reSP := regexp.MustCompile(`(\d+)\s*-?\s*sp(\d+)`)
 	if matches := reSP.FindStringSubmatch(osImageLower); len(matches) >= 3 {
+		return fmt.Sprintf("sles-%s.%s", matches[1], matches[2])
+	}
+
+	// major.minor notation (e.g. "16.0")
+	reMajorMinor := regexp.MustCompile(`(\d+)\.(\d+)`)
+	if matches := reMajorMinor.FindStringSubmatch(osImageLower); len(matches) >= 3 {
 		return fmt.Sprintf("sles-%s.%s", matches[1], matches[2])
 	}
 

--- a/internal/kmmmodule/kmmmodule_test.go
+++ b/internal/kmmmodule/kmmmodule_test.go
@@ -741,6 +741,7 @@ var _ = Describe("resolveDockerfile", func() {
 		}{
 			{"ubuntu-22.04", "docker.io/ubuntu:22.04"},
 			{"sles-15.6", "registry.suse.com/bci/bci-micro:15.6"},
+			{"sles-16.0", "registry.suse.com/bci/bci-micro:16.0"},
 		}
 		for _, tc := range testCases {
 			input := &amdv1alpha1.DeviceConfig{
@@ -760,6 +761,7 @@ var _ = Describe("resolveDockerfile", func() {
 		}{
 			{"ubuntu-22.04", "example-image-registry.com/ubuntu:22.04"},
 			{"sles-15.6", "example-image-registry.com/bci/bci-micro:15.6"},
+			{"sles-16.0", "example-image-registry.com/bci/bci-micro:16.0"},
 		}
 		for _, tc := range testCases {
 			input := &amdv1alpha1.DeviceConfig{

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -235,24 +235,34 @@ func UbuntuDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
 }
 
 var slesSPRegexp = regexp.MustCompile(`(\d+)\s*-?\s*sp(\d+)`)
+var slesMajorMinorRegexp = regexp.MustCompile(`(\d+)\.(\d+)`)
 
 var slesDefaultDriverVersions = map[string]string{
 	"15.7": "31.30",
+	"16.0": "31.30",
 }
 
-var supportedSLESVersions = []string{"SLES 15 SP7"}
+var supportedSLESVersions = []string{"SLES 15 SP7", "SLES 16.0"}
 
 // SlesCSDDriverVersions maps SLES codestream -> supported prebuilt driver versions.
 var SlesCSDDriverVersions = map[string][]string{
 	"15.7": {"7.0.3", "30.20.1", "30.30.3", "31.10", "31.20", "31.30"},
+	"16.0": {"31.10", "31.20", "31.30"},
 }
 
 func SLESDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
 	lower := strings.ToLower(fullImageStr)
+	var csVersion string
 
 	// SP-style notation used by SLES 15 (e.g. "15 SP7" or "15-sp7")
 	if match := slesSPRegexp.FindStringSubmatch(lower); len(match) >= 3 {
-		csVersion := fmt.Sprintf("%s.%s", match[1], match[2])
+		csVersion = fmt.Sprintf("%s.%s", match[1], match[2])
+	} else if match := slesMajorMinorRegexp.FindStringSubmatch(lower); len(match) >= 3 {
+		// major.minor notation used by SLES 16+ (e.g. "16.0")
+		csVersion = fmt.Sprintf("%s.%s", match[1], match[2])
+	}
+
+	if csVersion != "" {
 		if v, ok := slesDefaultDriverVersions[csVersion]; ok {
 			return v, nil
 		}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -250,6 +250,39 @@ var SlesCSDDriverVersions = map[string][]string{
 	"16.0": {"31.10", "31.20", "31.30"},
 }
 
+// slesCodestream extracts the codestream key (e.g. "15.7", "16.0") from an OS image string.
+func slesCodestream(osImage string) string {
+	lower := strings.ToLower(osImage)
+	if match := slesSPRegexp.FindStringSubmatch(lower); len(match) >= 3 {
+		return fmt.Sprintf("%s.%s", match[1], match[2])
+	}
+	if match := slesMajorMinorRegexp.FindStringSubmatch(lower); len(match) >= 3 {
+		return fmt.Sprintf("%s.%s", match[1], match[2])
+	}
+	return ""
+}
+
+// ValidateSLESDriverVersion checks whether driverVersion is supported for the
+// SLES codestream identified by osImage.
+func ValidateSLESDriverVersion(osImage, driverVersion string) error {
+	lower := strings.ToLower(osImage)
+	if !strings.Contains(lower, "suse") && !strings.Contains(lower, "sles") {
+		return nil
+	}
+	cs := slesCodestream(osImage)
+	versions, ok := SlesCSDDriverVersions[cs]
+	if !ok {
+		return fmt.Errorf("unsupported SLES codestream %q in OS image %q", cs, osImage)
+	}
+	for _, v := range versions {
+		if v == driverVersion {
+			return nil
+		}
+	}
+	return fmt.Errorf("driver version %q is not supported for SLES %s; supported versions: %s",
+		driverVersion, cs, strings.Join(versions, ", "))
+}
+
 func SLESDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
 	lower := strings.ToLower(fullImageStr)
 	var csVersion string

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -237,12 +237,14 @@ func UbuntuDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
 var slesSPRegexp = regexp.MustCompile(`(\d+)\s*-?\s*sp(\d+)`)
 
 var slesDefaultDriverVersions = map[string]string{
-	"15.7": "7.0.3",
+	"15.7": "31.30",
 }
+
+var supportedSLESVersions = []string{"SLES 15 SP7"}
 
 // SlesCSDDriverVersions maps SLES codestream -> supported prebuilt driver versions.
 var SlesCSDDriverVersions = map[string][]string{
-	"15.7": {"7.0.3"},
+	"15.7": {"7.0.3", "30.20.1", "30.30.3", "31.10", "31.20", "31.30"},
 }
 
 func SLESDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
@@ -255,7 +257,7 @@ func SLESDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
 			return v, nil
 		}
 	}
-	return "", fmt.Errorf("unsupported SLES version: %s. Supported versions include SLES 15 SP7 and above", fullImageStr)
+	return "", fmt.Errorf("unsupported SLES version: %s. Supported versions: %s", fullImageStr, strings.Join(supportedSLESVersions, ", "))
 }
 
 func HasNodeLabelKey(node v1.Node, labelKey string) bool {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -270,6 +270,9 @@ func ValidateSLESDriverVersion(osImage, driverVersion string) error {
 		return nil
 	}
 	cs := slesCodestream(osImage)
+	if cs == "" {
+		return fmt.Errorf("could not determine SLES codestream from OS image %q", osImage)
+	}
 	versions, ok := SlesCSDDriverVersions[cs]
 	if !ok {
 		return fmt.Errorf("unsupported SLES codestream %q in OS image %q", cs, osImage)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -234,16 +234,25 @@ func UbuntuDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
 	return "", fmt.Errorf("unsupported Ubuntu version: %s. Supported versions include 20.04, 22.04 and 24.04", fullImageStr)
 }
 
-var slesSPRegexp = regexp.MustCompile(`15\s*-?\s*sp(\d+)`)
+var slesSPRegexp = regexp.MustCompile(`(\d+)\s*-?\s*sp(\d+)`)
+
+var slesDefaultDriverVersions = map[string]string{
+	"15.7": "7.0.3",
+}
+
+// SlesCSDDriverVersions maps SLES codestream -> supported prebuilt driver versions.
+var SlesCSDDriverVersions = map[string][]string{
+	"15.7": {"7.0.3"},
+}
 
 func SLESDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
-	if strings.Contains(fullImageStr, "15") {
-		match := slesSPRegexp.FindStringSubmatch(strings.ToLower(fullImageStr))
-		if len(match) > 1 {
-			spVersion, err := strconv.Atoi(match[1])
-			if err == nil && spVersion >= 7 {
-				return "7.0.3", nil // Latest stable version for SP7+
-			}
+	lower := strings.ToLower(fullImageStr)
+
+	// SP-style notation used by SLES 15 (e.g. "15 SP7" or "15-sp7")
+	if match := slesSPRegexp.FindStringSubmatch(lower); len(match) >= 3 {
+		csVersion := fmt.Sprintf("%s.%s", match[1], match[2])
+		if v, ok := slesDefaultDriverVersions[csVersion]; ok {
+			return v, nil
 		}
 	}
 	return "", fmt.Errorf("unsupported SLES version: %s. Supported versions include SLES 15 SP7 and above", fullImageStr)

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -375,13 +375,13 @@ func TestSLESDefaultDriverVersionsMapper(t *testing.T) {
 		{
 			name:     "SLES 15 SP7",
 			osImage:  "SUSE Linux Enterprise Server 15 SP7",
-			expected: "7.0.3",
+			expected: slesDefaultDriverVersions["15.7"],
 			wantErr:  false,
 		},
 		{
 			name:     "SLES 15 SP7 with dash format",
 			osImage:  "sles 15-sp7",
-			expected: "7.0.3",
+			expected: slesDefaultDriverVersions["15.7"],
 			wantErr:  false,
 		},
 		{

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -375,19 +375,19 @@ func TestSLESDefaultDriverVersionsMapper(t *testing.T) {
 		{
 			name:     "SLES 15 SP7",
 			osImage:  "SUSE Linux Enterprise Server 15 SP7",
-			expected: slesDefaultDriverVersions["15.7"],
+			expected: "31.30",
 			wantErr:  false,
 		},
 		{
 			name:     "SLES 15 SP7 with dash format",
 			osImage:  "sles 15-sp7",
-			expected: slesDefaultDriverVersions["15.7"],
+			expected: "31.30",
 			wantErr:  false,
 		},
 		{
 			name:     "SLES 16.0",
 			osImage:  "SUSE Linux Enterprise Server 16.0",
-			expected: slesDefaultDriverVersions["16.0"],
+			expected: "31.30",
 			wantErr:  false,
 		},
 		{

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -417,3 +417,57 @@ func TestSLESDefaultDriverVersionsMapper(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSLESDriverVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		osImage       string
+		driverVersion string
+		wantErr       bool
+		errContains   string
+	}{
+		{
+			name:          "non-SLES OS is always valid",
+			osImage:       "Ubuntu 22.04.3 LTS",
+			driverVersion: "6.3.3",
+			wantErr:       false,
+		},
+		{
+			name:          "valid version for SLES 15 SP7",
+			osImage:       "SUSE Linux Enterprise Server 15 SP7",
+			driverVersion: "31.20",
+			wantErr:       false,
+		},
+		{
+			name:          "valid version for SLES 16.0",
+			osImage:       "SUSE Linux Enterprise Server 16.0",
+			driverVersion: "31.10",
+			wantErr:       false,
+		},
+		{
+			name:          "unsupported version on SLES 16.0",
+			osImage:       "SUSE Linux Enterprise Server 16.0",
+			driverVersion: "99.99",
+			wantErr:       true,
+			errContains:   "99.99",
+		},
+		{
+			name:          "unsupported version on SLES 15 SP7",
+			osImage:       "SUSE Linux Enterprise Server 15 SP7",
+			driverVersion: "0.0.0",
+			wantErr:       true,
+			errContains:   "0.0.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSLESDriverVersion(tt.osImage, tt.driverVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSLESDriverVersion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+			}
+		})
+	}
+}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -385,6 +385,12 @@ func TestSLESDefaultDriverVersionsMapper(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "SLES 16.0",
+			osImage:  "SUSE Linux Enterprise Server 16.0",
+			expected: slesDefaultDriverVersions["16.0"],
+			wantErr:  false,
+		},
+		{
 			name:    "SLES 15 SP6 unsupported",
 			osImage: "SUSE Linux Enterprise Server 15 SP6",
 			wantErr: true,

--- a/internal/validator/specValidators.go
+++ b/internal/validator/specValidators.go
@@ -67,6 +67,12 @@ func ValidateDriverSpec(ctx context.Context, client client.Client, devConfig *am
 		}
 	}
 
+	if dSpec.Version != "" {
+		if err := validateSLESDriverVersion(ctx, client, devConfig, dSpec.Version); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/internal/validator/utils.go
+++ b/internal/validator/utils.go
@@ -20,9 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	amdv1alpha1 "github.com/ROCm/gpu-operator/api/v1alpha1"
+	utils "github.com/ROCm/gpu-operator/internal"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,6 +35,22 @@ const (
 	ServiceMonitorCRDGroup   = "monitoring.coreos.com"
 	ServiceMonitorCRDVersion = "v1"
 )
+
+// validateSLESDriverVersion lists nodes matching devConfig's selector and, for any
+// SLES node found, checks that driverVersion is a known supported version.
+func validateSLESDriverVersion(ctx context.Context, cli client.Client, devConfig *amdv1alpha1.DeviceConfig, driverVersion string) error {
+	selector := labels.SelectorFromSet(labels.Set(devConfig.Spec.Selector))
+	nodeList := &v1.NodeList{}
+	if err := cli.List(ctx, nodeList, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return fmt.Errorf("failed to list nodes for driver version validation: %v", err)
+	}
+	for _, node := range nodeList.Items {
+		if err := utils.ValidateSLESDriverVersion(node.Status.NodeInfo.OSImage, driverVersion); err != nil {
+			return fmt.Errorf("version validation failed for node %s: %w", node.Name, err)
+		}
+	}
+	return nil
+}
 
 func validateSecret(ctx context.Context, client client.Client, secretRef *v1.LocalObjectReference, namespace string) error {
 	if secretRef == nil || secretRef.Name == "" {


### PR DESCRIPTION
## Motivation

Follow up to https://github.com/ROCm/gpu-operator/pull/365 to extend SLES 16.0 support, and some controller validation improvements.

## Technical Details

The PR is making the folllowing changes:

- extend SLES support to include `SLES 16.0` OS (along with the existing `SLES 15 SP7`)
   - new prebuilt driver versions for both codestreams:
      - SLES 16.0 `31.10`, `31.20`, `31.30`
      - SLES 15 SP7 -  `30.20.1`, `30.30.3`, `31.10`, `31.20`, `31.30`
  - refactor the driver image lookup into the shared `internal/utils` package  
    (so, both KMM module builder and the spec validator use the same meta)

- add reconcile-time validation to reject unsupported driver versions for SLES nodes with a clear status condition on the DeviceConfig object

    ```
    > kubectl get deviceconfig mi355x-driver-test -n kube-amd-gpu -o jsonpath='{.status}'| jq .
    {
      "conditions": [
        {
          "lastTransitionTime": "2026-05-29T13:11:09Z",
          "message": "Validation failed: [driver version validation failed for node 144.xx.xx.xx.xx: driver version \"31.50\" is not supported for SLES 16.0; supported versions: 31.10, 31.20, 31.30]",
          "reason": "ValidationError",
          "status": "True",
          "type": "Error"
        },
        {
          "lastTransitionTime": "2026-05-29T13:11:09Z",
          "message": "",
          "reason": "OperatorReady",
          "status": "False",
          "type": "Ready"
        }
      ]
    }
    ```

- also add a new `NoMatchingNodes` condition in the DeviceConfig status, to surface error when no cluster nodes match the node selector defined in the DeviceConfig manifest.

  This condition will clear when node selector condition is satisfied.
 
   In my local testing, when NFD labels (for allowing GPU device ID) are absent on the node, the DeviceConfig admission happens silently with no error/feedback in the DeviceConfig status. but the operator loops indefinitely with reconciler errors in logs (and these errors are easy to go unnoticed).
    
    
    ```
    > kubectl get deviceconfig mi355x-driver-test -n kube-amd-gpu -o jsonpath='{.status}'| jq .
    {
      "conditions": [
        {
          "lastTransitionTime": "2026-05-29T13:44:42Z",
          "message": "",
          "reason": "OperatorReady",
          "status": "False",
          "type": "Ready"
        },
        {
          "lastTransitionTime": "2026-05-29T13:44:42Z",
          "message": "no nodes found matching selector feature.node.kubernetes.io/amd-gpu=true; verify node labels or check that NFD has labeled the GPU nodes",
          "reason": "NoMatchingNodes",
          "status": "True",
          "type": "Error"
        }
      ],
      ...
    ```



## Test Plan

Please note, these changes are validated on a MI355X system with SLES 16.0 (provided by AMD) across all amdgpu driver versions included in the PR.


## Test Result

Added unit tests for

- `SLESDefaultDriverVersionsMapper` (covering SP7 and 16.0 OS image parsing)
- `ValidateSLESDriverVersion` (to cover valid/invalid driver versions for both codestreams and non-SLES passthrough)
- `resolveDockerfile` (covering SLES 16.0 prebuilt image tag resolution in both default and custom registry scenarios)

truncated output of `make unit-test`

```
> make unit-test
go vet ./...
go test ./internal ./internal/controllers ./internal/kmmmodule -v -coverprofile cover.out
...
...
=== RUN   TestSLESDefaultDriverVersionsMapper
=== RUN   TestSLESDefaultDriverVersionsMapper/SLES_15_SP7
=== RUN   TestSLESDefaultDriverVersionsMapper/SLES_15_SP7_with_dash_format
=== RUN   TestSLESDefaultDriverVersionsMapper/SLES_16.0
=== RUN   TestSLESDefaultDriverVersionsMapper/SLES_15_SP6_unsupported
=== RUN   TestSLESDefaultDriverVersionsMapper/SLES_15_base_unsupported
--- PASS: TestSLESDefaultDriverVersionsMapper (0.00s)
    --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_15_SP7 (0.00s)
    --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_15_SP7_with_dash_format (0.00s)
    --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_16.0 (0.00s)
    --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_15_SP6_unsupported (0.00s)
    --- PASS: TestSLESDefaultDriverVersionsMapper/SLES_15_base_unsupported (0.00s)
=== RUN   TestValidateSLESDriverVersion
=== RUN   TestValidateSLESDriverVersion/non-SLES_OS_is_always_valid
=== RUN   TestValidateSLESDriverVersion/valid_version_for_SLES_15_SP7
=== RUN   TestValidateSLESDriverVersion/valid_version_for_SLES_16.0
=== RUN   TestValidateSLESDriverVersion/unsupported_version_on_SLES_16.0
=== RUN   TestValidateSLESDriverVersion/unsupported_version_on_SLES_15_SP7
--- PASS: TestValidateSLESDriverVersion (0.00s)
    --- PASS: TestValidateSLESDriverVersion/non-SLES_OS_is_always_valid (0.00s)
    --- PASS: TestValidateSLESDriverVersion/valid_version_for_SLES_15_SP7 (0.00s)
    --- PASS: TestValidateSLESDriverVersion/valid_version_for_SLES_16.0 (0.00s)
    --- PASS: TestValidateSLESDriverVersion/unsupported_version_on_SLES_16.0 (0.00s)
    --- PASS: TestValidateSLESDriverVersion/unsupported_version_on_SLES_15_SP7 (0.00s)
PASS
coverage: 53.2% of statements
ok  	github.com/ROCm/gpu-operator/internal	0.019s	coverage: 53.2% of statements
=== RUN   TestAPIs
Running Suite: Controller Suite - /home/amd/work-suse/may-29-2026/gpu-operator/internal/controllers
===================================================================================================
Random Seed: 1780062369

Will run 25 of 25 specs
•••••••••••••••••••••••••

Ran 25 of 25 Specs in 0.003 seconds
SUCCESS! -- 25 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (0.00s)
PASS
coverage: 7.4% of statements
ok  	github.com/ROCm/gpu-operator/internal/controllers	0.023s	coverage: 7.4% of statements
=== RUN   TestAPIs
Running Suite: KMMModule Suite - /home/amd/work-suse/may-29-2026/gpu-operator/internal/kmmmodule
================================================================================================
Random Seed: 1780062369

Will run 9 of 9 specs
testing multiple valid homogeneous nodes
testing multiple valid heterogeneous nodes
testing multiple valid heterogeneous nodes + one unsupported node
testing multiple unsupported nodes
testing empty node list
•••••••<moduleName>
<amdgpu>
•<moduleName>
<amdgpu>
•

Ran 9 of 9 Specs in 0.004 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAPIs (0.01s)
PASS
coverage: 46.4% of statements
ok  	github.com/ROCm/gpu-operator/internal/kmmmodule	0.020s	coverage: 46.4% of statements
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
