### PR TITLE
replace hardcoded SlesCSDDriverVersions map with actual registry.suse.com check 

### DIFF
--- a/docs/specialized_networks/airgapped-install.md
+++ b/docs/specialized_networks/airgapped-install.md
@@ -37,6 +37,10 @@ gcr.io/kaniko-project/executor:v1.23.2
 docker.io/ubuntu:<Ubuntu OS version>
 docker.io/busybox:1.36
 
+# SLES base and prebuilt driver images (only needed for SLES GPU nodes)
+registry.suse.com/bci/bci-micro:<codestream>  # e.g. 15.7 or 16.0
+registry.suse.com/third-party/amd/amdgpu-driver:sles-<codestream>-<ga-kernel>-default-<driver-version>
+
 # Node Feature Discovery
 registry.k8s.io/nfd/node-feature-discovery:v0.18.3
 
@@ -142,6 +146,22 @@ docker push ${INTERNAL_REGISTRY}/busybox:${BUSYBOX_VERSION}
 docker pull registry.k8s.io/nfd/node-feature-discovery:${NFD_VERSION}
 docker tag registry.k8s.io/nfd/node-feature-discovery:${NFD_VERSION} ${INTERNAL_REGISTRY}/nfd/node-feature-discovery:${NFD_VERSION}
 docker push ${INTERNAL_REGISTRY}/nfd/node-feature-discovery:${NFD_VERSION}
+
+# SLES base and prebuilt driver images (only needed for SLES GPU nodes)
+# Update these to match your SLES codestream and driver version.
+# GA_KERNEL is the kernel version embedded in the SUSE prebuilt image tag — check registry.suse.com/third-party/amd/amdgpu-driver for available tags.
+CODESTREAM="16.0"               # e.g. 15.7 or 16.0
+GA_KERNEL="6.12.0-160000.5"     # GA kernel for the codestream
+DRIVER_VERSION="31.30"          # same as spec.driver.version in DeviceConfig
+SLES_TAG="sles-${CODESTREAM}-${GA_KERNEL}-default-${DRIVER_VERSION}"
+
+docker pull registry.suse.com/bci/bci-micro:${CODESTREAM}
+docker tag  registry.suse.com/bci/bci-micro:${CODESTREAM} ${INTERNAL_REGISTRY}/bci/bci-micro:${CODESTREAM}
+docker push ${INTERNAL_REGISTRY}/bci/bci-micro:${CODESTREAM}
+
+docker pull registry.suse.com/third-party/amd/amdgpu-driver:${SLES_TAG}
+docker tag  registry.suse.com/third-party/amd/amdgpu-driver:${SLES_TAG} ${INTERNAL_REGISTRY}/third-party/amd/amdgpu-driver:${SLES_TAG}
+docker push ${INTERNAL_REGISTRY}/third-party/amd/amdgpu-driver:${SLES_TAG}
 
 # Cert-manager images
 CERT_MANAGER_IMAGES=(
@@ -298,6 +318,23 @@ spec:
   configManager:
     enable: false
     image: internal-registry.example.com/rocm/device-config-manager:<version>
+```
+
+```{Note}
+For **SLES GPU nodes**, also set `spec.driver.imageBuild.baseImageRegistry` to your internal
+registry. This tells the operator to pull both the `bci-micro` base image and the SUSE prebuilt
+driver source from the internal mirror instead of `registry.suse.com`. The image paths under the
+internal registry must preserve the original SUSE paths (`/bci/bci-micro` and
+`/third-party/amd/amdgpu-driver`), as mirrored in step 1.
+```
+
+```yaml
+  driver:
+    enable: true
+    version: "<driver-version>"
+    image: internal-registry.example.com/rocm/driver-image
+    imageBuild:
+      baseImageRegistry: "internal-registry.example.com"
 ```
 
 ## Verification

--- a/internal/kmmmodule/kmmmodule.go
+++ b/internal/kmmmodule/kmmmodule.go
@@ -104,18 +104,17 @@ var slesCSDGAKernel = map[string]string{
 }
 
 // slesPrebuiltDriverImage returns the full prebuilt image reference.
-func slesPrebuiltDriverImage(codestream, driverVersion string) (string, bool) {
+func slesPrebuiltDriverImage(codestream, driverVersion, customRepo string) (string, bool) {
 	gaKernel, ok := slesCSDGAKernel[codestream]
 	if !ok {
 		return "", false
 	}
-	for _, v := range utils.SlesCSDDriverVersions[codestream] {
-		if v == driverVersion {
-			tag := fmt.Sprintf("sles-%s-%s-default-%s", codestream, gaKernel, driverVersion)
-			return slesPrebuiltDriverImageRepo + ":" + tag, true
-		}
+	tag := fmt.Sprintf("sles-%s-%s-default-%s", codestream, gaKernel, driverVersion)
+	repo := slesPrebuiltDriverImageRepo
+	if customRepo != "" {
+		repo = customRepo
 	}
-	return "", false
+	return repo + ":" + tag, true
 }
 
 //go:generate mockgen -source=kmmmodule.go -package=kmmmodule -destination=mock_kmmmodule.go KMMModuleAPI
@@ -601,7 +600,13 @@ func getKM(devConfig *amdv1alpha1.DeviceConfig, node v1.Node, inTreeModuleToRemo
 		if _, ok := slesCSDGAKernel[csVersion]; !ok {
 			return kmmv1beta1.KernelMapping{}, "", fmt.Errorf("no prebuilt driver image registered for SLES codestream %q", csVersion)
 		}
-		prebuiltImg, ok := slesPrebuiltDriverImage(csVersion, driversVersion)
+		// if custom baseImageRegistry is set (e.g. air-gapped mirror), use that
+		// otherwise use the default "registry.suse.com"
+		prebuiltRepo := ""
+		if devConfig.Spec.Driver.ImageBuild.BaseImageRegistry != "" {
+			prebuiltRepo = devConfig.Spec.Driver.ImageBuild.BaseImageRegistry + "/third-party/amd/amdgpu-driver"
+		}
+		prebuiltImg, ok := slesPrebuiltDriverImage(csVersion, driversVersion, prebuiltRepo)
 		if !ok {
 			return kmmv1beta1.KernelMapping{}, "", fmt.Errorf("no prebuilt driver image registered for SLES codestream %q with driver version %q", csVersion, driversVersion)
 		}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -18,11 +18,15 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
@@ -242,13 +246,23 @@ var slesDefaultDriverVersions = map[string]string{
 	"16.0": "31.30",
 }
 
-var supportedSLESVersions = []string{"SLES 15 SP7", "SLES 16.0"}
+var (
+	slesRegistryHTTPClient  = &http.Client{Timeout: 10 * time.Second}
+	slesRegistryAuthURL     = "https://scc.suse.com/api/registry/authorize?service=SUSE+Linux+Docker+Registry&scope=repository:third-party/amd/amdgpu-driver:pull"
+	slesRegistryManifestFmt = "https://registry.suse.com/v2/third-party/amd/amdgpu-driver/manifests/sles-%s-%s"
+)
 
-// SlesCSDDriverVersions maps SLES codestream -> supported prebuilt driver versions.
-var SlesCSDDriverVersions = map[string][]string{
-	"15.7": {"7.0.3", "30.20.1", "30.30.3", "31.10", "31.20", "31.30"},
-	"16.0": {"31.10", "31.20", "31.30"},
+// slesVersionCache caches registry check results for 5 minutes to avoid redundant calls.
+type slesVersionCacheEntry struct {
+	err       error
+	expiresAt time.Time
 }
+
+var (
+	slesVersionCache    = map[string]slesVersionCacheEntry{}
+	slesVersionCacheMu  sync.RWMutex
+	slesVersionCacheTTL = 5 * time.Minute
+)
 
 // slesCodestream extracts the codestream key (e.g. "15.7", "16.0") from an OS image string.
 func slesCodestream(osImage string) string {
@@ -262,9 +276,8 @@ func slesCodestream(osImage string) string {
 	return ""
 }
 
-// ValidateSLESDriverVersion checks whether driverVersion is supported for the
-// SLES codestream identified by osImage.
-func ValidateSLESDriverVersion(osImage, driverVersion string) error {
+// ValidateSLESDriverVersion checks driverVersion availability on registry.suse.com for the given SLES osImage.
+func ValidateSLESDriverVersion(ctx context.Context, osImage, driverVersion string) error {
 	lower := strings.ToLower(osImage)
 	if !strings.Contains(lower, "suse") && !strings.Contains(lower, "sles") {
 		return nil
@@ -273,17 +286,60 @@ func ValidateSLESDriverVersion(osImage, driverVersion string) error {
 	if cs == "" {
 		return fmt.Errorf("could not determine SLES codestream from OS image %q", osImage)
 	}
-	versions, ok := SlesCSDDriverVersions[cs]
-	if !ok {
-		return fmt.Errorf("unsupported SLES codestream %q in OS image %q", cs, osImage)
+
+	cacheKey := cs + "@" + driverVersion
+	slesVersionCacheMu.RLock()
+	e, hit := slesVersionCache[cacheKey]
+	slesVersionCacheMu.RUnlock()
+	if hit && time.Now().Before(e.expiresAt) {
+		logr.FromContextOrDiscard(ctx).Info("SLES driver version cache hit", "codestream", cs, "version", driverVersion)
+		return e.err
 	}
-	for _, v := range versions {
-		if v == driverVersion {
-			return nil
-		}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, slesRegistryAuthURL, nil)
+	if err != nil {
+		return err
 	}
-	return fmt.Errorf("driver version %q is not supported for SLES %s; supported versions: %s",
-		driverVersion, cs, strings.Join(versions, ", "))
+	resp, err := slesRegistryHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("could not reach SUSE registry: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("SCC auth request failed with status %d", resp.StatusCode)
+	}
+	var tok struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
+		return fmt.Errorf("could not parse SCC token: %w", err)
+	}
+
+	req, err = http.NewRequestWithContext(ctx, http.MethodHead, fmt.Sprintf(slesRegistryManifestFmt, cs, driverVersion), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	resp2, err := slesRegistryHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("could not reach SUSE registry: %w", err)
+	}
+	defer resp2.Body.Close()
+
+	var result error
+	switch resp2.StatusCode {
+	case http.StatusOK:
+		result = nil
+	case http.StatusNotFound:
+		result = fmt.Errorf("driver version %q is not available for SLES %s on registry.suse.com", driverVersion, cs)
+	default:
+		result = fmt.Errorf("unexpected status %d from SUSE registry for SLES %s version %q", resp2.StatusCode, cs, driverVersion)
+	}
+	slesVersionCacheMu.Lock()
+	slesVersionCache[cacheKey] = slesVersionCacheEntry{err: result, expiresAt: time.Now().Add(slesVersionCacheTTL)}
+	slesVersionCacheMu.Unlock()
+	logr.FromContextOrDiscard(ctx).Info("SLES driver version cache refreshed", "codestream", cs, "version", driverVersion, "available", result == nil)
+	return result
 }
 
 func SLESDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
@@ -303,7 +359,7 @@ func SLESDefaultDriverVersionsMapper(fullImageStr string) (string, error) {
 			return v, nil
 		}
 	}
-	return "", fmt.Errorf("unsupported SLES version: %s. Supported versions: %s", fullImageStr, strings.Join(supportedSLESVersions, ", "))
+	return "", fmt.Errorf("unsupported SLES version %q", fullImageStr)
 }
 
 func HasNodeLabelKey(node v1.Node, labelKey string) bool {

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -419,54 +422,77 @@ func TestSLESDefaultDriverVersionsMapper(t *testing.T) {
 }
 
 func TestValidateSLESDriverVersion(t *testing.T) {
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"token":"test-token"}`)
+	}))
+	defer authServer.Close()
+
+	var mockStatusCode int
+	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(mockStatusCode)
+	}))
+	defer registryServer.Close()
+
+	origAuthURL, origManifestFmt := slesRegistryAuthURL, slesRegistryManifestFmt
+	t.Cleanup(func() { slesRegistryAuthURL, slesRegistryManifestFmt = origAuthURL, origManifestFmt })
+	slesRegistryAuthURL = authServer.URL
+	slesRegistryManifestFmt = registryServer.URL + "/v2/third-party/amd/amdgpu-driver/manifests/sles-%s-%s"
+
 	tests := []struct {
-		name          string
-		osImage       string
-		driverVersion string
-		wantErr       bool
-		errContains   string
+		name           string
+		osImage        string
+		driverVersion  string
+		registryStatus int
+		wantErr        bool
+		wantErrMsg     string
 	}{
 		{
-			name:          "non-SLES OS is always valid",
-			osImage:       "Ubuntu 22.04.3 LTS",
-			driverVersion: "6.3.3",
-			wantErr:       false,
+			name:           "non-SLES OS is always valid",
+			osImage:        "Ubuntu 22.04.3 LTS",
+			driverVersion:  "6.3.3",
+			registryStatus: http.StatusOK,
+			wantErr:        false,
 		},
 		{
-			name:          "valid version for SLES 15 SP7",
-			osImage:       "SUSE Linux Enterprise Server 15 SP7",
-			driverVersion: "31.20",
-			wantErr:       false,
+			name:           "valid version for SLES 15 SP7",
+			osImage:        "SUSE Linux Enterprise Server 15 SP7",
+			driverVersion:  "31.20",
+			registryStatus: http.StatusOK,
+			wantErr:        false,
 		},
 		{
-			name:          "valid version for SLES 16.0",
-			osImage:       "SUSE Linux Enterprise Server 16.0",
-			driverVersion: "31.10",
-			wantErr:       false,
+			name:           "valid version for SLES 16.0",
+			osImage:        "SUSE Linux Enterprise Server 16.0",
+			driverVersion:  "31.10",
+			registryStatus: http.StatusOK,
+			wantErr:        false,
 		},
 		{
-			name:          "unsupported version on SLES 16.0",
-			osImage:       "SUSE Linux Enterprise Server 16.0",
-			driverVersion: "99.99",
-			wantErr:       true,
-			errContains:   "99.99",
+			name:           "unavailable version on SLES 16.0",
+			osImage:        "SUSE Linux Enterprise Server 16.0",
+			driverVersion:  "99.99",
+			registryStatus: http.StatusNotFound,
+			wantErr:        true,
+			wantErrMsg:     `driver version "99.99" is not available for SLES 16.0 on registry.suse.com`,
 		},
 		{
-			name:          "unsupported version on SLES 15 SP7",
-			osImage:       "SUSE Linux Enterprise Server 15 SP7",
-			driverVersion: "0.0.0",
-			wantErr:       true,
-			errContains:   "0.0.0",
+			name:           "unavailable version on SLES 15 SP7",
+			osImage:        "SUSE Linux Enterprise Server 15 SP7",
+			driverVersion:  "0.0.0",
+			registryStatus: http.StatusNotFound,
+			wantErr:        true,
+			wantErrMsg:     `driver version "0.0.0" is not available for SLES 15.7 on registry.suse.com`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateSLESDriverVersion(tt.osImage, tt.driverVersion)
+			mockStatusCode = tt.registryStatus
+			err := ValidateSLESDriverVersion(context.Background(), tt.osImage, tt.driverVersion)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateSLESDriverVersion() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if tt.wantErr && tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
-				t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+			if tt.wantErr && tt.wantErrMsg != "" && err.Error() != tt.wantErrMsg {
+				t.Errorf("error = %q, want %q", err.Error(), tt.wantErrMsg)
 			}
 		})
 	}

--- a/internal/validator/utils.go
+++ b/internal/validator/utils.go
@@ -22,6 +22,7 @@ import (
 
 	amdv1alpha1 "github.com/ROCm/gpu-operator/api/v1alpha1"
 	utils "github.com/ROCm/gpu-operator/internal"
+	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,16 +38,28 @@ const (
 )
 
 // validateSLESDriverVersion lists nodes matching devConfig's selector and, for any
-// SLES node found, checks that driverVersion is a known supported version.
+// SLES node found, checks that driverVersion is available on the SUSE registry.
+// Validation is skipped when baseImageRegistry is set (custom/air-gapped mirror).
 func validateSLESDriverVersion(ctx context.Context, cli client.Client, devConfig *amdv1alpha1.DeviceConfig, driverVersion string) error {
+	if devConfig.Spec.Driver.ImageBuild.BaseImageRegistry != "" {
+		logr.FromContextOrDiscard(ctx).Info("Skipping SLES driver version registry validation: custom base image registry configured",
+			"baseImageRegistry", devConfig.Spec.Driver.ImageBuild.BaseImageRegistry)
+		return nil
+	}
 	selector := labels.SelectorFromSet(labels.Set(devConfig.Spec.Selector))
 	nodeList := &v1.NodeList{}
 	if err := cli.List(ctx, nodeList, &client.ListOptions{LabelSelector: selector}); err != nil {
 		return fmt.Errorf("failed to list nodes for driver version validation: %v", err)
 	}
+	seen := map[string]struct{}{}
 	for _, node := range nodeList.Items {
-		if err := utils.ValidateSLESDriverVersion(node.Status.NodeInfo.OSImage, driverVersion); err != nil {
-			return fmt.Errorf("version validation failed for node %s: %w", node.Name, err)
+		osImage := node.Status.NodeInfo.OSImage
+		if _, ok := seen[osImage]; ok {
+			continue
+		}
+		seen[osImage] = struct{}{}
+		if err := utils.ValidateSLESDriverVersion(ctx, osImage, driverVersion); err != nil {
+			return fmt.Errorf("driver version validation failed for node %s: %w", node.Name, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Motivation

follow up on point (1) - https://github.com/ROCm/gpu-operator/pull/562#issuecomment-4654323994

## Technical Details

```
> kubectl get deviceconfig driver-test -n kube-amd-gpu -o jsonpath-as-json="{.status}"
[
    {
        "conditions": [
            {
                "lastTransitionTime": "2026-06-09T16:01:19Z",
                "message": "Validation failed: [driver driver version validation failed for node ip-172-xx-xx-xx: driver version \"31.40\" is not available for SLES 16.0 on registry.suse.com]",
                "reason": "ValidationError",
                "status": "True",
                "type": "Error"
            },
            {
                "lastTransitionTime": "2026-06-09T16:01:19Z",
                "message": "",
                "reason": "OperatorReady",
                "status": "False",
                "type": "Ready"
            }
        ]
    }
]
```

and cache logs would look like:


```
2026-06-09T14:16:28.13.083 INFO SLES driver version cache refreshed  {"codestream": "16.0", "version": "31.80", "available": false}
2026-06-09T14:16.28.13.100 INFO SLES driver version cache refreshed  {"codestream": "16.0", "version": "31.40", "available": false}
2026-06-09T14:16.28.13.120 INFO SLES driver version cache hit         {"codestream": "16.0", "version": "31.30", "available": true}
2026-06-09T14:16:28.54.100 INFO SLES driver version cache hit         {"codestream": "16.0", "version": "31.80", "available": false}
```


## Test Plan

updated test in `internal/utils_test.go`, to rewrite TestValidateSLESDriverVersion to accomodate the new model of driver version validation

## Test Result

```
> go test ./internal/ -run TestValidateSLESDriverVersion -v -count=1
=== RUN   TestValidateSLESDriverVersion
=== RUN   TestValidateSLESDriverVersion/non-SLES_OS_is_always_valid
=== RUN   TestValidateSLESDriverVersion/valid_version_for_SLES_15_SP7
=== RUN   TestValidateSLESDriverVersion/valid_version_for_SLES_16.0
=== RUN   TestValidateSLESDriverVersion/unavailable_version_on_SLES_16.0
=== RUN   TestValidateSLESDriverVersion/unavailable_version_on_SLES_15_SP7
--- PASS: TestValidateSLESDriverVersion (0.00s)
    --- PASS: TestValidateSLESDriverVersion/non-SLES_OS_is_always_valid (0.00s)
    --- PASS: TestValidateSLESDriverVersion/valid_version_for_SLES_15_SP7 (0.00s)
    --- PASS: TestValidateSLESDriverVersion/valid_version_for_SLES_16.0 (0.00s)
    --- PASS: TestValidateSLESDriverVersion/unavailable_version_on_SLES_16.0 (0.00s)
    --- PASS: TestValidateSLESDriverVersion/unavailable_version_on_SLES_15_SP7 (0.00s)
PASS
ok  	github.com/ROCm/gpu-operator/internal	0.017s
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
