### PR TITLE
ci: add unit test workflow on pull requests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,22 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    branches:
+    - main
+    - 'release-*'
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.4'
+
+      - name: Run unit tests
+        run: make unit-test


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/unit-test.yml` — a new CI workflow that runs unit tests on every PR targeting `main` or `release-*` branches.
- Uses Go 1.26.4 (matching `go.mod`) and runs `make unit-test`, which covers `./internal`, `./internal/controllers`, and `./internal/kmmmodule`.

## Test plan

- [ ] Verify the workflow triggers on a PR to `main`
- [ ] Confirm all 3 packages pass (`internal`, `controllers`, `kmmmodule`)
- [ ] Confirm the workflow is skipped on non-PR events