### PR TITLE
ci: gate build, unit-test, and lint workflows on CI-Run label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - main
     - 'release-*'
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
     branches:
     - main
     - 'release-*'
+    types: [labeled]
 
 jobs:
   build:
+    if: contains(github.event.pull_request.labels.*.name, 'CI-Run')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
     - main
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
   call-workflow-passing-data:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,8 +7,10 @@ on:
   pull_request:
     branches:
     - main
+    types: [labeled]
 
 jobs:
   call-workflow-passing-data:
     name: Documentation
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI-Run')
     uses: ROCm/rocm-docs-core/.github/workflows/linting.yml@develop

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,9 +5,11 @@ on:
     branches:
     - main
     - 'release-*'
+    types: [labeled]
 
 jobs:
   unit-test:
+    if: contains(github.event.pull_request.labels.*.name, 'CI-Run')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - main
     - 'release-*'
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
   unit-test:


### PR DESCRIPTION
## Summary

- Build, Unit Tests, and Linting workflows now only run on PRs when the `CI-Run` label is present
- Workflows fire on the `labeled` event type; jobs have an `if` condition checking for the label
- Linting retains its `push` to `main` trigger so it still runs after merges

## Behavior

| Event | CI-Run label present | Runs? |
|---|---|---|
| PR opened / new commits pushed | — | No |
| Label `CI-Run` added to PR | Yes | Yes |
| Push to `main` (linting only) | N/A | Yes |

## Notes

- Who can add the `CI-Run` label is controlled via GitHub repo settings (triage role or above) — no workflow changes needed for that
- The `CI-Run` label needs to be created in the repo under **Issues → Labels**