### PR TITLE
ci: improve PR workflow hygiene (concurrency, dispatch, timeout, go-version-file)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,14 @@ on:
     branches:
     - main
     - 'release-*'
-    types: [labeled, synchronize]
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    if: contains(github.event.pull_request.labels.*.name, 'CI-Run')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - main
     - 'release-*'
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ on:
     branches:
     - main
     - 'release-*'
+    types: [labeled]
 
 jobs:
   build:
+    if: contains(github.event.pull_request.labels.*.name, 'CI-Run')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,10 +7,9 @@ on:
   pull_request:
     branches:
     - main
-    types: [labeled, synchronize]
+  workflow_dispatch:
 
 jobs:
   call-workflow-passing-data:
     name: Documentation
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI-Run')
     uses: ROCm/rocm-docs-core/.github/workflows/linting.yml@develop

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
     - main
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
   call-workflow-passing-data:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,8 +7,10 @@ on:
   pull_request:
     branches:
     - main
+    types: [labeled]
 
 jobs:
   call-workflow-passing-data:
     name: Documentation
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CI-Run')
     uses: ROCm/rocm-docs-core/.github/workflows/linting.yml@develop

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,9 +5,11 @@ on:
     branches:
     - main
     - 'release-*'
+    types: [labeled]
 
 jobs:
   unit-test:
+    if: contains(github.event.pull_request.labels.*.name, 'CI-Run')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,11 +6,17 @@ on:
     - main
     - 'release-*'
     types: [labeled, synchronize]
+  workflow_dispatch:
+
+concurrency:
+  group: unit-test-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   unit-test:
-    if: contains(github.event.pull_request.labels.*.name, 'CI-Run')
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'CI-Run')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -18,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.4'
+          go-version-file: 'go.mod'
 
       - name: Run unit tests
         run: make unit-test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - main
     - 'release-*'
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
   unit-test:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - main
     - 'release-*'
-    types: [labeled, synchronize]
   workflow_dispatch:
 
 concurrency:
@@ -14,7 +13,6 @@ concurrency:
 
 jobs:
   unit-test:
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'CI-Run')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

- Add `concurrency` group with `cancel-in-progress: true` to unit-test workflow — cancels stale runs when new commits arrive on the same ref
- Add `workflow_dispatch` trigger so the workflow can be run manually from the GitHub UI; updated the label-gate `if` condition to allow it
- Add `timeout-minutes: 15` to prevent hung jobs from consuming runners indefinitely
- Switch from hardcoded `go-version: '1.26.4'` to `go-version-file: 'go.mod'` so the Go version is always in sync with what the repo declares

Mirrors patterns already used in the [device-metrics-exporter](https://github.com/ROCm/device-metrics-exporter) repo.

## Test plan

- [ ] Verify workflow appears in the Actions tab with a "Run workflow" button after merge
- [ ] Open a PR and confirm label-gated runs still only trigger with `CI-Run` label
- [ ] Confirm a second push to the same PR branch cancels the in-progress run