### PR TITLE
Bump version to v1.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,8 @@ USER 201:201
 LABEL name="amd-gpu-operator" \ 
     maintainer="yan.sun3@amd.com,shrey.ajmera@amd.com,nitish.bhat@amd.com,praveenkumar.shanmugam@amd.com" \
     vendor="Advanced Micro Devices, Inc." \
-    version="dev" \
-    release="dev" \
+    version="v1.5.1" \
+    release="v1.5.1" \
     summary="The AMD GPU Operator simplifies the management and deployment of AMD GPUs on Kubernetes cluster" \
     description="The AMD GPU Operator controller manager images are essential for managing, deploying, and orchestrating AMD GPU resources and operations within Kubernetes clusters. It streamline various tasks, including automated driver installation and management, easy deployment of the AMD GPU device plugin, and metrics collection and export. Its operands could simplify GPU resource allocation for containers, automatically label worker nodes with GPU properties, and provide comprehensive GPU health monitoring and troubleshooting."
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifneq ("$(wildcard dev.env)","")
 endif
 
 # Default version for the project.
-PROJECT_VERSION ?= v0.0.1
+PROJECT_VERSION ?= v1.5.1
 
 ####################################
 # GPU Operator Image Build variables

--- a/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -35,8 +35,8 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: AI/Machine Learning,Monitoring
-    containerImage: registry.test.pensando.io:5000/amd-gpu-operator:dev
-    createdAt: "2026-07-09T09:40:15Z"
+    containerImage: docker.io/rocm/amd-gpu-operator:v1.5.1
+    createdAt: "2026-07-18T00:47:23Z"
     description: |-
       Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
       For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)
@@ -1643,7 +1643,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: docker.io/rocm/amd-gpu-operator:dev
+                image: docker.io/rocm/amd-gpu-operator:v1.5.1
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml
@@ -57,7 +57,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/ROCm/gpu-operator
     support: Advanced Micro Devices, Inc.
-  name: amd-gpu-operator.v0.0.1
+  name: amd-gpu-operator.v1.5.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1764,4 +1764,4 @@ spec:
   maturity: stable
   provider:
     name: Advanced Micro Devices, Inc.
-  version: 0.0.1
+  version: 1.5.1

--- a/config/manager-base/kustomization.yaml
+++ b/config/manager-base/kustomization.yaml
@@ -10,7 +10,7 @@ patches:
 images:
 - name: controller
   newName: docker.io/rocm/amd-gpu-operator
-  newTag: dev
+  newTag: v1.5.1
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
 - name: controller
   newName: docker.io/rocm/amd-gpu-operator
-  newTag: dev
+  newTag: v1.5.1
 
 configMapGenerator:
 - files:

--- a/config/manifests/bases/amd-gpu-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/amd-gpu-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
     categories: AI/Machine Learning,Monitoring
-    containerImage: docker.io/rocm/amd-gpu-operator:dev
+    containerImage: docker.io/rocm/amd-gpu-operator:v1.5.1
     description: |-
       Operator responsible for deploying AMD GPU kernel drivers, device plugin, device test runner and device metrics exporter
       For more information, visit [documentation](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ external_projects = ["amd-gpu-operator"]
 external_projects_current_project = "amd-gpu-operator"
 
 project = "AMD GPU Operator"
-version = "1.5.0"
+version = "1.5.1"
 release = version
 html_title = f"{project} {version}"
 author = "Advanced Micro Devices, Inc."

--- a/hack/k8s-patch/metadata-patch/Chart.yaml
+++ b/hack/k8s-patch/metadata-patch/Chart.yaml
@@ -19,8 +19,8 @@ keywords:
   - monitoring
 
 kubeVersion: ">= 1.29.0-0"
-version: v0.0.1
-appVersion: "dev"
+version: v1.5.1
+appVersion: "v1.5.1"
 
 dependencies:
 - name: node-feature-discovery

--- a/hack/k8s-patch/metadata-patch/values.yaml
+++ b/hack/k8s-patch/metadata-patch/values.yaml
@@ -319,7 +319,7 @@ controllerManager:
       # -- AMD GPU operator controller manager image repository
       repository: docker.io/rocm/amd-gpu-operator
       # -- AMD GPU operator controller manager image tag
-      tag: dev
+      tag: v1.5.1
     # -- Image pull policy for AMD GPU operator controller manager pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image

--- a/helm-charts-k8s/Chart.lock
+++ b/helm-charts-k8s/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: file://./charts/remediation-crds
   version: v1.0.0
 digest: sha256:0806f6b6d7aa21be77bf1c91e720ae3238338a16f107df450a53b02ef940db1b
-generated: "2026-07-09T09:40:11.647230235Z"
+generated: "2026-07-18T00:47:19.697884107Z"

--- a/helm-charts-k8s/Chart.yaml
+++ b/helm-charts-k8s/Chart.yaml
@@ -19,8 +19,8 @@ keywords:
   - monitoring
 
 kubeVersion: ">= 1.29.0-0"
-version: v0.0.1
-appVersion: "dev"
+version: v1.5.1
+appVersion: "v1.5.1"
 
 dependencies:
 - name: node-feature-discovery

--- a/helm-charts-k8s/README.md
+++ b/helm-charts-k8s/README.md
@@ -125,7 +125,7 @@ The AMD GPU Operator is licensed under the [Apache License 2.0](LICENSE).
 
 ## gpu-operator-charts
 
-![Version: v0.0.1](https://img.shields.io/badge/Version-v0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: dev](https://img.shields.io/badge/AppVersion-dev-informational?style=flat-square)
+![Version: v1.5.1](https://img.shields.io/badge/Version-v1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.5.1](https://img.shields.io/badge/AppVersion-v1.5.1-informational?style=flat-square)
 
 AMD GPU Operator simplifies the deployment and management of AMD Instinct GPU accelerators within Kubernetes clusters.
 

--- a/helm-charts-k8s/README.md
+++ b/helm-charts-k8s/README.md
@@ -6,7 +6,7 @@ For the most detailed and up-to-date documentation please visit our Instinct Doc
 
 ## Introduction
 
-AMD GPU Operator simplifies the deployment and management of AMD Instinct GPU accelerators within Kubernetes clusters. This project enables seamless configuration and operation of GPU-accelerated workloads, including machine learning, Generative AI, and other GPU-intensive applications.
+AMD GPU Operator simplifies the deployment and management of AMD Instinct™ and AMD Radeon™ GPU accelerators within Kubernetes clusters. This project enables seamless configuration and operation of GPU-accelerated workloads, including machine learning, Generative AI, and other GPU-intensive applications.
 
 ## Components
 
@@ -158,7 +158,7 @@ Kubernetes: `>= 1.29.0-0`
 | global.imagePullSecrets | list | `[]` | Global image pull secret(s) applied to all component pods and subcharts. If specified, these secrets will be used by: - GPU operator controller manager deployment - Remediation workflow controller - All helm hooks (pre-upgrade, pre-delete, post-delete) - DeviceConfig-managed components (via commonConfig.imageRegistrySecrets) - KMM controller and webhook pods (automatically inherited) - KMM builder/signer/worker pods (automatically uses first secret as fallback)  Format: [{"name": "myGlobalSecret"}] or [{"name": "secret1"}, {"name": "secret2"}]  Note: For NFD subchart, you must manually set the field to match global secrets:   node-feature-discovery.imagePullSecrets: [{"name": "myGlobalSecret"}] |
 | controllerManager.affinity | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]},"weight":1}]}}` | Deployment affinity configs for controller manager |
 | controllerManager.manager.image.repository | string | `"docker.io/rocm/amd-gpu-operator"` | AMD GPU operator controller manager image repository |
-| controllerManager.manager.image.tag | string | `"dev"` | AMD GPU operator controller manager image tag |
+| controllerManager.manager.image.tag | string | `"v1.5.1"` | AMD GPU operator controller manager image tag |
 | controllerManager.manager.imagePullPolicy | string | `"Always"` | Image pull policy for AMD GPU operator controller manager pod |
 | controllerManager.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image |
 | controllerManager.nodeSelector | object | `{}` | Node selector for AMD GPU operator controller manager deployment |

--- a/helm-charts-k8s/crds/deviceconfig-crd.yaml
+++ b/helm-charts-k8s/crds/deviceconfig-crd.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: gpu-operator-charts-v1.5.1
     app.kubernetes.io/name: gpu-operator-charts
     app.kubernetes.io/instance: amd-gpu
-    app.kubernetes.io/version: "dev"
+    app.kubernetes.io/version: "v1.5.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   group: amd.com

--- a/helm-charts-k8s/crds/deviceconfig-crd.yaml
+++ b/helm-charts-k8s/crds/deviceconfig-crd.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/component: amd-gpu
     app.kubernetes.io/part-of: amd-gpu
-    helm.sh/chart: gpu-operator-charts-v0.0.1
+    helm.sh/chart: gpu-operator-charts-v1.5.1
     app.kubernetes.io/name: gpu-operator-charts
     app.kubernetes.io/instance: amd-gpu
     app.kubernetes.io/version: "dev"

--- a/helm-charts-k8s/crds/remediationworkflowstatus-crd.yaml
+++ b/helm-charts-k8s/crds/remediationworkflowstatus-crd.yaml
@@ -9,10 +9,10 @@ metadata:
   labels:
     app.kubernetes.io/component: amd-gpu
     app.kubernetes.io/part-of: amd-gpu
-    helm.sh/chart: gpu-operator-charts-v0.0.1
+    helm.sh/chart: gpu-operator-charts-v1.5.1
     app.kubernetes.io/name: gpu-operator-charts
     app.kubernetes.io/instance: amd-gpu
-    app.kubernetes.io/version: "dev"
+    app.kubernetes.io/version: "v1.5.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   group: amd.com

--- a/helm-charts-k8s/values.yaml
+++ b/helm-charts-k8s/values.yaml
@@ -319,7 +319,7 @@ controllerManager:
       # -- AMD GPU operator controller manager image repository
       repository: docker.io/rocm/amd-gpu-operator
       # -- AMD GPU operator controller manager image tag
-      tag: dev
+      tag: v1.5.1
     # -- Image pull policy for AMD GPU operator controller manager pod
     imagePullPolicy: Always
     # -- Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image

--- a/internal/configmanager/configmanager.go
+++ b/internal/configmanager/configmanager.go
@@ -58,7 +58,7 @@ import (
 
 const (
 	// TODO: determine where to host the config manager image and put the registry URL here
-	defaultConfigManagerImage = "docker.io/rocm/device-config-manager:v0.0.1"
+	defaultConfigManagerImage = "docker.io/rocm/device-config-manager:v1.5.1"
 	ConfigManagerName         = "device-config-manager"
 	defaultSAName             = "amd-gpu-operator-config-manager"
 	defaultInitContainerImage = "busybox:1.36"

--- a/internal/controllers/remediation_handler.go
+++ b/internal/controllers/remediation_handler.go
@@ -68,7 +68,7 @@ const (
 	RemediationTaintKey        = "amd-gpu-unhealthy"
 	DefaultConfigMapSuffix     = "default-conditional-workflow-mappings"
 	DefaultTemplate            = "default-template"
-	DefaultTestRunnerImage     = "docker.io/rocm/test-runner:v0.0.1"
+	DefaultTestRunnerImage     = "docker.io/rocm/test-runner:v1.5.1"
 	TestRunnerServiceAccount   = "amd-gpu-operator-test-runner"
 	AmdGpuRemediationRequired  = "amd-gpu-remediation-required"
 	AmdGpuRemediationSucceeded = "amd-gpu-remediation-succeeded"

--- a/internal/controllers/upgrademgr.go
+++ b/internal/controllers/upgrademgr.go
@@ -1327,8 +1327,8 @@ func (h *upgradeMgrHelper) getRebootPod(nodeName string, dc *amdv1alpha1.DeviceC
 			ImagePullSecrets:   imagePullSecrets,
 			Containers: []v1.Container{
 				{
-					Name:            "reboot-container",
-					Image:           utilsImage,
+					Name:  "reboot-container",
+					Image: utilsImage,
 					// Flush filesystems before reboot to avoid exec-format errors from unflushed overlay writes.
 					Command:         []string{"/nsenter", "--all", "--target=1", "--", "sh", "-c", "sync; sudo reboot"},
 					Stdin:           true,

--- a/internal/metricsexporter/metricsexporter.go
+++ b/internal/metricsexporter/metricsexporter.go
@@ -53,7 +53,7 @@ import (
 )
 
 const (
-	defaultMetricsExporterImage       = "docker.io/rocm/device-metrics-exporter:v0.0.1"
+	defaultMetricsExporterImage       = "docker.io/rocm/device-metrics-exporter:v1.5.1"
 	defaultKubeRbacProxyImage         = "quay.io/brancz/kube-rbac-proxy:v0.18.1"
 	defaultInitContainerImage         = "busybox:1.36"
 	servicePort                 int32 = 5000

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -52,7 +52,7 @@ import (
 
 const (
 	// TODO: determine where to host the test runner image and put the registry URL here
-	defaultTestRunnerImage       = "docker.io/rocm/test-runner:v0.0.1"
+	defaultTestRunnerImage       = "docker.io/rocm/test-runner:v1.5.1"
 	defaultInitContainerImage    = "busybox:1.36"
 	TestRunnerName               = "test-runner"
 	defaultSAName                = "amd-gpu-operator-test-runner"

--- a/internal/utils_container/Dockerfile
+++ b/internal/utils_container/Dockerfile
@@ -3,8 +3,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 LABEL name="amd-gpu-operator-utils"
 LABEL maintainer="sriram.ravishankar@amd.com,yan.sun3@amd.com"
 LABEL vendor="Advanced Micro Devices, Inc."
-LABEL version="dev"
-LABEL release="dev"
+LABEL version="v1.5.1"
+LABEL release="v1.5.1"
 LABEL summary="AMD GPU Operator Utility Image"
 LABEL description="The AMD GPU Operator utils image is a utility image used by the AMD GPU Operator. The operator controller employs this image as the container's base layer to automate tasks on target worker nodes."
 


### PR DESCRIPTION
## Summary

Bootstraps the `release-v1.5.1` branch by bumping the project version from `v0.0.1`/`dev`/`1.5.0` to `v1.5.1`. Ports the version-bump portion of pensando/gpu-operator#1610 to the public repo.

Changes across:
- Build config: `Makefile` (`PROJECT_VERSION`)
- Image labels: `Dockerfile`, `internal/utils_container/Dockerfile`
- Helm charts: `helm-charts-k8s/Chart.yaml`, `README.md`, `crds/deviceconfig-crd.yaml`, `hack/k8s-patch/metadata-patch/Chart.yaml`
- OLM bundle: `bundle/manifests/amd-gpu-operator.clusterserviceversion.yaml`
- Docs: `docs/conf.py` (`1.5.0` → `1.5.1`)
- Default operand image tags: `device-metrics-exporter`, `test-runner`, `device-config-manager` (all `v0.0.1` → `v1.5.1`)

## Test plan
- [ ] `make helm` produces charts tagged `v1.5.1`
- [ ] Operator deploys operands using `:v1.5.1` image tags