### PR TITLE
docs: bump v1.5.0 references to v1.5.1

### DIFF
--- a/docs/contributing/developer-guide.md
+++ b/docs/contributing/developer-guide.md
@@ -128,7 +128,7 @@ docker run --rm \
   gpu-op-k8s-e2e:latest \
   -kubeconfig /kubeconfig \
   -operatorchart /helm-charts \
-  -operatortag v1.5.0 \
+  -operatortag v1.5.1 \
   -test.timeout 60m
 ```
 
@@ -146,7 +146,7 @@ docker run --rm -v /path/to/kubeconfig:/kubeconfig:ro \
 
 ```bash
 # Full install+verify+teardown
-make -C tests/k8s-e2e all KUBECONFIG=/path/to/kubeconfig OPERATOR_TAG=v1.5.0
+make -C tests/k8s-e2e all KUBECONFIG=/path/to/kubeconfig OPERATOR_TAG=v1.5.1
 
 # Verify only (pre-deployed)
 make -C tests/k8s-e2e verify KUBECONFIG=/path/to/kubeconfig

--- a/docs/dcm/applying-partition-profiles.rst
+++ b/docs/dcm/applying-partition-profiles.rst
@@ -176,7 +176,7 @@ After creating the ConfigMap, you need to associate it with the Device Config Ma
       enable: True
 
       # image for the device-config-manager container
-      image: "rocm/device-config-manager:v1.5.0"
+      image: "rocm/device-config-manager:v1.5.1"
 
       # image pull policy for config manager. Accepted values are Always, IfNotPresent, Never
       imagePullPolicy: IfNotPresent

--- a/docs/dcm/device-config-manager.md
+++ b/docs/dcm/device-config-manager.md
@@ -26,7 +26,7 @@ The Device Config Manager can be enabled by setting the `spec/configManager/enab
     enable: True
 
     # image for the device-config-manager container
-    image: "rocm/device-config-manager:v1.5.0"
+    image: "rocm/device-config-manager:v1.5.1"
 
     # image pull policy for config manager. Accepted values are Always, IfNotPresent, Never
     imagePullPolicy: IfNotPresent

--- a/docs/drivers/installation.md
+++ b/docs/drivers/installation.md
@@ -80,7 +80,7 @@ spec:
      serviceType: "NodePort"
      # Node port for metrics exporter service, metrics endpoint $node-ip:$nodePort
      nodePort: 32500
-     image: docker.io/rocm/device-metrics-exporter:v1.5.0
+     image: docker.io/rocm/device-metrics-exporter:v1.5.1
 
   # Specifythe node to be managed by this DeviceConfig Custom Resource
   selector:
@@ -159,7 +159,7 @@ spec:
      serviceType: "NodePort"
      # Node port for metrics exporter service, metrics endpoint $node-ip:$nodePort
      nodePort: 32500
-     image: docker.io/rocm/device-metrics-exporter:v1.5.0
+     image: docker.io/rocm/device-metrics-exporter:v1.5.1
 
   # Specifythe node to be managed by this DeviceConfig Custom Resource
   selector:

--- a/docs/installation/kubernetes-helm.md
+++ b/docs/installation/kubernetes-helm.md
@@ -119,7 +119,7 @@ To install the latest version of the GPU Operator run the following Helm install
 helm install amd-gpu-operator rocm/gpu-operator-charts \
   --namespace kube-amd-gpu \
   --create-namespace \
-  --version=v1.5.0
+  --version=v1.5.1
 ```
 
 ```{note}
@@ -155,7 +155,7 @@ Installation Options
     helm install amd-gpu-operator rocm/gpu-operator-charts \
       --namespace kube-amd-gpu \
       --create-namespace \
-      --version=v1.5.0 \
+      --version=v1.5.1 \
       --set global.imagePullSecrets[0].name=my-registry-secret
     ```
 
@@ -171,7 +171,7 @@ Installation with custom options:
 helm install amd-gpu-operator rocm/gpu-operator-charts \
   --namespace kube-amd-gpu \
   --create-namespace \
-  --version=v1.5.0 \
+  --version=v1.5.1 \
   -f values.yaml
 ```
 
@@ -181,7 +181,7 @@ The following parameters are able to be configued when using the Helm Chart. In 
 |-----|------|---------|-------------|
 | controllerManager.affinity | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]},"weight":1}]}}` | Deployment affinity configs for controller manager |
 | controllerManager.manager.image.repository | string | `"docker.io/rocm/gpu-operator"` | AMD GPU operator controller manager image repository |
-| controllerManager.manager.image.tag | string | `"v1.5.0"` | AMD GPU operator controller manager image tag |
+| controllerManager.manager.image.tag | string | `"v1.5.1"` | AMD GPU operator controller manager image tag |
 | controllerManager.manager.imagePullPolicy | string | `"Always"` | Image pull policy for AMD GPU operator controller manager pod |
 | controllerManager.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling AMD GPU operator controller manager image if registry needs credential to pull image |
 | controllerManager.manager.resources.limits.cpu | string | `"1000m"` | CPU limits for the controller manager. Consider increasing for large clusters |
@@ -201,12 +201,12 @@ The following parameters are able to be configued when using the Helm Chart. In 
 | kmm.controller.manager.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | kmm.controller.manager.env.relatedImageBuild | string | `"gcr.io/kaniko-project/executor:v1.23.2"` | KMM kaniko builder image for building driver image within cluster |
 | kmm.controller.manager.env.relatedImageBuildPullSecret | string | `""` | Image pull secret name for pulling KMM kaniko builder image if registry needs credential to pull image |
-| kmm.controller.manager.env.relatedImageSign | string | `"docker.io/rocm/kernel-module-management-signimage:v1.5.0"` | KMM signer image for signing driver image's kernel module with given key pairs within cluster |
+| kmm.controller.manager.env.relatedImageSign | string | `"docker.io/rocm/kernel-module-management-signimage:v1.5.1"` | KMM signer image for signing driver image's kernel module with given key pairs within cluster |
 | kmm.controller.manager.env.relatedImageSignPullSecret | string | `""` | Image pull secret name for pulling KMM signer image if registry needs credential to pull image |
-| kmm.controller.manager.env.relatedImageWorker | string | `"docker.io/rocm/kernel-module-management-worker:v1.5.0"` | KMM worker image for loading / unloading driver kernel module on worker nodes |
+| kmm.controller.manager.env.relatedImageWorker | string | `"docker.io/rocm/kernel-module-management-worker:v1.5.1"` | KMM worker image for loading / unloading driver kernel module on worker nodes |
 | kmm.controller.manager.env.relatedImageWorkerPullSecret | string | `""` | Image pull secret name for pulling KMM worker image if registry needs credential to pull image |
 | kmm.controller.manager.image.repository | string | `"docker.io/rocm/kernel-module-management-operator"` | KMM controller manager image repository |
-| kmm.controller.manager.image.tag | string | `"v1.5.0"` | KMM controller manager image tag |
+| kmm.controller.manager.image.tag | string | `"v1.5.1"` | KMM controller manager image tag |
 | kmm.controller.manager.imagePullPolicy | string | `"Always"` | Image pull policy for KMM controller manager pod |
 | kmm.controller.manager.imagePullSecrets | string | `""` | Image pull secret name for pulling KMM controller manager image if registry needs credential to pull image |
 | kmm.controller.manager.resources.limits.cpu | string | `"500m"` |  |
@@ -360,7 +360,7 @@ spec:
      serviceType: "NodePort"
      # Node port for metrics exporter service, metrics endpoint $node-ip:$nodePort
      nodePort: 32500
-     image: docker.io/rocm/device-metrics-exporter:v1.5.0
+     image: docker.io/rocm/device-metrics-exporter:v1.5.1
 
   # Specifythe node to be managed by this DeviceConfig Custom Resource
   selector:
@@ -412,7 +412,7 @@ spec:
      serviceType: "NodePort"
      # Node port for metrics exporter service, metrics endpoint $node-ip:$nodePort
      nodePort: 32500
-     image: docker.io/rocm/device-metrics-exporter:v1.5.0
+     image: docker.io/rocm/device-metrics-exporter:v1.5.1
 
   # Specifythe node to be managed by this DeviceConfig Custom Resource
   selector:

--- a/docs/metrics/exporter.md
+++ b/docs/metrics/exporter.md
@@ -44,7 +44,7 @@ metricsExporter:
     nodePort: 32500
 
     # image for the metrics-exporter container
-    image: "rocm/device-metrics-exporter:v1.5.0"
+    image: "rocm/device-metrics-exporter:v1.5.1"
  
 ```
 

--- a/docs/test/auto-unhealthy-device-test.md
+++ b/docs/test/auto-unhealthy-device-test.md
@@ -25,7 +25,7 @@ metricsExporter:
     nodePort: 32500
 
     # image for the metrics-exporter container
-    image: "rocm/device-metrics-exporter:v1.5.0"
+    image: "rocm/device-metrics-exporter:v1.5.1"
 
 # Specify the test runner config
 testRunner:
@@ -33,7 +33,7 @@ testRunner:
     enable: true
 
     # image for the test runner container
-    image: docker.io/rocm/test-runner:v1.5.0
+    image: docker.io/rocm/test-runner:v1.5.1
 
     # specify the mount for test logs
     logsLocation:

--- a/docs/test/logs-export.md
+++ b/docs/test/logs-export.md
@@ -166,7 +166,7 @@ Example:
     enable: True
 
     # testrunner image
-    image: docker.io/rocm/test-runner:v1.5.0
+    image: docker.io/rocm/test-runner:v1.5.1
 
     # image pull policy for the testrunner
     # default value is IfNotPresent for valid tags, Always for no tag or "latest" tag

--- a/docs/test/manual-test.md
+++ b/docs/test/manual-test.md
@@ -124,7 +124,7 @@ spec:
         name: test-runner-volume
       containers:
       - name: amd-test-runner
-        image: docker.io/rocm/test-runner:v1.5.0
+        image: docker.io/rocm/test-runner:v1.5.1
         imagePullPolicy: IfNotPresent
         securityContext: # setup security context for container to get access to device related interfaces
           privileged: true
@@ -274,7 +274,7 @@ spec:
           requests:
             amd.com/gpu: 8 # requesting all GPUs on the node
         name: amd-test-runner
-        image: docker.io/rocm/test-runner:v1.5.0
+        image: docker.io/rocm/test-runner:v1.5.1
         imagePullPolicy: IfNotPresent
         securityContext: # setup security context for container to get access to device related interfaces
           privileged: true
@@ -450,7 +450,7 @@ spec:
             name: test-runner-volume
           containers:
           - name: init-test-runner
-            image: docker.io/rocm/test-runner:v1.5.0
+            image: docker.io/rocm/test-runner:v1.5.1
             imagePullPolicy: IfNotPresent
             securityContext: # setup security context for container to get access to device related interfaces
               privileged: true
@@ -660,7 +660,7 @@ spec:
         name: test-runner-volume
       containers:
       - name: amd-test-runner
-        image: docker.io/rocm/test-runner:v1.5.0
+        image: docker.io/rocm/test-runner:v1.5.1
         imagePullPolicy: IfNotPresent
         securityContext: # setup security context for container to get access to device related interfaces
           privileged: true
@@ -832,7 +832,7 @@ spec:
         name: test-runner-volume
       containers:
       - name: amd-test-runner
-        image: docker.io/rocm/test-runner:v1.5.0
+        image: docker.io/rocm/test-runner:v1.5.1
         imagePullPolicy: IfNotPresent
         securityContext: # setup security context for container to get access to device related interfaces
           privileged: true

--- a/docs/test/pre-start-job-test.md
+++ b/docs/test/pre-start-job-test.md
@@ -120,7 +120,7 @@ spec:
         name: test-runner-volume
       initContainers:
       - name: init-test-runner
-        image: docker.io/rocm/test-runner:v1.5.0
+        image: docker.io/rocm/test-runner:v1.5.1
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/docs/upgrades/componentupgrades.md
+++ b/docs/upgrades/componentupgrades.md
@@ -121,7 +121,7 @@ Updated CR:
     enable: True
     serviceType: "ClusterIP"
     port: 5000
-    image: rocm/device-metrics-exporter:v1.5.0
+    image: rocm/device-metrics-exporter:v1.5.1
     upgradePolicy:
       upgradeStrategy: OnDelete
 ```

--- a/docs/upgrades/upgrade.md
+++ b/docs/upgrades/upgrade.md
@@ -68,12 +68,12 @@ helm repo update
 # Perform helm upgrade
 helm upgrade amd-gpu-operator rocm/gpu-operator-charts \
   -n kube-amd-gpu \
-  --version=v1.5.0 \
+  --version=v1.5.1 \
   --debug
 ```
 
 * When upgrading a Helm chart, customized operator controller image URLs set in the older version's values.yaml (via `--set` or `-f values.yaml`) will persist due to default Helm behavior.
-* To ensure a successful upgrade, you must use the target version's operator image in the helm upgrade command. This is because upgrade hooks rely on the target version's images for CRD updates. For example, to upgrade to v1.5.0 when you already customized operator image URL in old version helm chart, use `--set` to ask helm for using correct version image for executing helm upgrade hooks:
+* To ensure a successful upgrade, you must use the target version's operator image in the helm upgrade command. This is because upgrade hooks rely on the target version's images for CRD updates. For example, to upgrade to v1.5.1 when you already customized operator image URL in old version helm chart, use `--set` to ask helm for using correct version image for executing helm upgrade hooks:
 
 ```bash
 # Fetch latest info from helm repo
@@ -81,10 +81,10 @@ helm repo update
 # Perform helm upgrade
 helm upgrade amd-gpu-operator rocm/gpu-operator-charts \
   -n kube-amd-gpu \
-  --version=v1.5.0 \
+  --version=v1.5.1 \
   --debug \
   --set controllerManager.manager.image.repository=docker.io/rocm/gpu-operator \
-  --set controllerManager.manager.image.tag=v1.5.0 
+  --set controllerManager.manager.image.tag=v1.5.1 
 ```
 
 ```{note}


### PR DESCRIPTION
## Summary
Several docs on `release-v1.5.1` still referenced `v1.5.0` in release-pinned version strings while the chart/images ship as `v1.5.1`. This updates them:

- **Helm install guide** (`docs/installation/kubernetes-helm.md`): `helm install --version`, chart parameter-table image tags (controller manager + KMM signer/worker/controller), and DeviceConfig `device-metrics-exporter` examples.
- **Image tags** across guides: `device-metrics-exporter`, `device-config-manager`, and `test-runner` in `docs/drivers/installation.md`, `docs/metrics/exporter.md`, `docs/dcm/*`, `docs/test/*`, and `docs/upgrades/componentupgrades.md`.
- **Upgrade guide** (`docs/upgrades/upgrade.md`): `helm upgrade --version` and the `--set controllerManager.manager.image.tag` example.
- **Developer guide** (`docs/contributing/developer-guide.md`): e2e `-operatortag` / `OPERATOR_TAG` build args.

### Intentionally left unchanged
- `docs/releasenotes.md` — describes the v1.5.0 release specifically.
- `docs/installation/kubernetes-helm.md` "Global Image Pull Secrets (v1.5.0+)" note — marks the feature-introduction version.
- `docs/specialized_networks/airgapped-install.md` — the `e.g., "v1.5.0"` comment example (actual value is v1.4.1).

## Test plan
- [ ] Docs render correctly (no broken formatting in changed code blocks / table rows)
- [ ] `git grep v1.5.0 -- docs/` returns only the intentional exclusions listed above