### PR TITLE
Generate llms files with rocm_docs_generate_llms

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ html_theme = "rocm_docs_theme"
 html_theme_options = {
     "flavor": "instinct",
     "link_main_doc": True,
+    "use_download_button": True,
     "repository_url": "https://github.com/rocm/gpu-operator",
     # Add any additional theme options here
     "announcement": (
@@ -36,6 +37,11 @@ extensions = ["rocm_docs","sphinx_substitution_extensions"]
 external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
+
+# Generate llms.txt and llms-full.txt after each build (the llms.txt standard,
+# https://llmstxt.org/). See the rocm-docs-core guide:
+# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/user_guide/llms.html
+rocm_docs_generate_llms = True
 
 rst_prolog = """
 .. |version| replace:: v{version}

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,3 +1,3 @@
-rocm-docs-core==1.18.1
+rocm-docs-core[llms]==1.38.0
 sphinx-reredirects
 Sphinx-Substitution-Extensions==2025.6.6

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -19,6 +19,8 @@ babel==2.16.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
+beartype==0.22.9
+    # via sphinx-substitution-extensions
 beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
 breathe==4.35.0
@@ -51,6 +53,8 @@ docutils==0.21.2
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinx-markdown-builder
+    #   sphinx-substitution-extensions
 exceptiongroup==1.2.2
     # via ipython
 executing==2.2.0
@@ -118,7 +122,9 @@ mdurl==0.1.2
 myst-nb==1.1.2
     # via rocm-docs-core
 myst-parser==4.0.0
-    # via myst-nb
+    # via
+    #   myst-nb
+    #   sphinx-substitution-extensions
 nbclient==0.10.2
     # via
     #   jupyter-cache
@@ -133,6 +139,7 @@ nest-asyncio==1.6.0
 packaging==24.2
     # via
     #   ipykernel
+    #   pydata-sphinx-theme
     #   sphinx
 parso==0.8.4
     # via jedi
@@ -150,7 +157,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pydata-sphinx-theme==0.16.0
+pydata-sphinx-theme==0.15.4
     # via
     #   rocm-docs-core
     #   sphinx-book-theme
@@ -187,7 +194,7 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.18.1
+rocm-docs-core[llms]==1.38.0
     # via -r requirements.in
 rpds-py==0.22.3
     # via
@@ -212,9 +219,11 @@ sphinx==8.1.3
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-external-toc
+    #   sphinx-markdown-builder
     #   sphinx-notfound-page
     #   sphinx-reredirects
-sphinx-book-theme==1.1.3
+    #   sphinx-substitution-extensions
+sphinx-book-theme==1.1.4
     # via rocm-docs-core
 sphinx-copybutton==0.5.2
     # via rocm-docs-core
@@ -222,9 +231,13 @@ sphinx-design==0.6.1
     # via rocm-docs-core
 sphinx-external-toc==1.0.1
     # via rocm-docs-core
+sphinx-markdown-builder==0.6.10
+    # via rocm-docs-core
 sphinx-notfound-page==1.0.4
     # via rocm-docs-core
 sphinx-reredirects==0.1.6
+    # via -r requirements.in
+sphinx-substitution-extensions==2025.6.6
     # via -r requirements.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -243,7 +256,9 @@ sqlalchemy==2.0.37
 stack-data==0.6.3
     # via ipython
 tabulate==0.9.0
-    # via jupyter-cache
+    # via
+    #   jupyter-cache
+    #   sphinx-markdown-builder
 tomli==2.1.0
     # via sphinx
 tornado==6.4.2
@@ -278,4 +293,3 @@ wrapt==1.17.0
     # via deprecated
 zipp==3.21.0
     # via importlib-metadata
-Sphinx-Substitution-Extensions==2025.6.6


### PR DESCRIPTION
## Motivation

Enable llms.txt / llms-full.txt generation for the AMD GPU Operator docs, so the site publishes machine-readable documentation following the llms.txt standard (https://llmstxt.org/). This aligns the project with the shared approach used across the Instinct documentation set (k8s-device-plugin, container-toolkit, gpu-cluster-networking, amdgpu-docs, instinct-docs), using the built-in support in rocm-docs-core.

## Technical Details

- Enable generation via rocm_docs_generate_llms = True in docs/conf.py, which produces both llms.txt and llms-full.txt from the resolved doctree at build time.
- Add use_download_button: True to html_theme_options for the per-page Markdown download button.
- Bump rocm-docs-core from 1.18.1 to 1.38.0 and add the [llms] extra in docs/sphinx/requirements.in; regenerate requirements.txt (Python 3.10, matching .readthedocs.yaml), which pulls in sphinx-markdown-builder. Existing pins (sphinx-reredirects,  Sphinx-Substitution-Extensions) are preserved.

Uses rocm-docs-core 1.38.0 rather than the latest 1.39.0: the published 1.39.0 wheel ships a malformed projects.yaml that breaks the build (already fixed upstream on develop, pending a patch release).

## Test Plan

- Regenerated docs/sphinx/requirements.txt with pip-compile under Python 3.10; confirmed the [llms] extra and existing dependencies resolve.
- Ran a full sphinx-build -b html in a clean python:3.10-slim container with the pinned requirements, reproducing the Read the Docs environment.
- Verified llms.txt and llms-full.txt are generated and inspected their content.

## Test Result

Build succeeds (build succeeded, 24 warnings) and logs Wrote llms.txt and llms-full.txt. Generated llms.txt (4 KB) has the correct # AMD GPU Operator header and indexes all pages; llms-full.txt (576 KB) has correct per-page sections with prose filtering. The 24 warnings are pre-existing, unrelated to this change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
