### PR TITLE
docs: declare SLES 15 / 16 as supported platform in 1.5.1

### DIFF
--- a/docs/drivers/precompiled-driver.md
+++ b/docs/drivers/precompiled-driver.md
@@ -29,11 +29,14 @@ KMM looks for driver images based on tags, the controller will use these methods
 | --------- | ----------- | ------------------- |
 | `Ubuntu 24.04.1 LTS` | `Ubuntu` | `24.04` |
 | `Red Hat Enterprise Linux CoreOS 9.6.20250916-0 (Plow)` | `coreos` | `9.6` |
+| `SUSE Linux Enterprise Server 15 SP7` | `sles` | `15.7` |
+| `SUSE Linux Enterprise Server 16.0` | `sles` | `16.0` |
 
 | OS | Tag Format | Example Image Tag |
 | ---- | ------------ | ------------------- |
 | `ubuntu` | `ubuntu-<OS version>-<kernel>-<driver version>` | `ubuntu-22.04-6.8.0-40-generic-6.1.3` |
 | `coreos` | `coreos-<OS version>-<kernel>-<driver version>` | `coreos-9.6-5.14.0-427.28.1.el9_4.x86_64-6.2.2` |
+| `sles` | `sles-<codestream>-<GA kernel>-default-<driver version>` | `sles-15.7-6.4.0-150700.53-default-31.30` |
 
 When a DeviceConfig is created with driver management enabled (`spec.driver.enable=true`), KMM will:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,16 @@ Below is a matrix of supported Operating systems and the corresponding Kubernete
       <td style="border: 1px solid grey;"></td>
     </tr>
     <tr style="background-color: white; color: black;">
+      <td style="background-color: #2c2c2c; color: white; border: 1px solid grey;">SUSE Linux Enterprise Server 15</td>
+      <td style="border: 1px solid grey;">1.29-1.36</td>
+      <td style="border: 1px solid grey;"></td>
+    </tr>
+    <tr style="background-color: lightgrey; color: black;">
+      <td style="background-color: #2c2c2c; color: white; border: 1px solid grey;">SUSE Linux Enterprise Server 16</td>
+      <td style="border: 1px solid grey;">1.29-1.36</td>
+      <td style="border: 1px solid grey;"></td>
+    </tr>
+    <tr style="background-color: white; color: black;">
       <td style="background-color: #2c2c2c; color: white; border: 1px solid grey;">Red Hat Core OS (RHCOS)</td>
       <td style="border: 1px solid grey;"></td>
       <td style="border: 1px solid grey;">4.16—4.22</td>

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -22,6 +22,11 @@ The AMD GPU Operator v1.5.1 release extends hardware support to the **AMD Instin
 - **ROCm 7.14 Managed Stack**
   - The metrics exporter, test runner, and DCM operand images are packaged with ROCm 7.14 runtime libraries in this release.
 
+- **SUSE Linux Enterprise Server (SLES) Support**
+  - The GPU Operator now supports SLES 15 and SLES 16 GPU worker nodes on vanilla Kubernetes.
+  - Driver management (KMM) resolves prebuilt amdgpu driver images from `registry.suse.com`, and the DeviceConfig spec validates the requested driver version against the SUSE registry before rollout.
+  - The AMD GPU Operator is listed as **SUSE Ready** for SLES 15 and SLES 16 in the [SUSE Partner Software Catalog](https://www.suse.com/pcsc/viewVersionPage?versionID=26965).
+
 - **Device Metrics Exporter: Configurable Exporter Arguments**
   - The Helm chart now supports passing arbitrary arguments to the exporter at deploy time via new deployment options:
     - `--exit-on-rocpctl-error`: Exit instead of auto-disabling profiler metrics after consecutive errors.
@@ -32,6 +37,7 @@ The AMD GPU Operator v1.5.1 release extends hardware support to the **AMD Instin
 
 - **AMD Instinct™ MI350P**: Kubernetes 1.29 – 1.36, OpenShift 4.21 – 4.22
 - **AMD Radeon™ AI PRO**: Kubernetes 1.29 – 1.36
+- **SUSE Linux Enterprise Server (SLES) 15 / 16**: Kubernetes 1.29 – 1.36
 
 ### Fixes
 


### PR DESCRIPTION
## Summary
- Declares **SLES 15** and **SLES 16** as supported platforms in the 1.5.1 GA docs on the `release-v1.5.1` branch. The SLES code support is already in 1.5.1; this adds the missing docs declaration.
- Ports the equivalent change already merged downstream and already present on `ROCm/main`.

## Changes
- `docs/index.md` — SLES 15 / 16 rows in the OS & Platform Support Matrix (Kubernetes `1.29-1.36`, matching every other row)
- `docs/releasenotes.md` — SLES highlight bullet + Platform Support line + a link to the [SUSE Partner Software Catalog](https://www.suse.com/pcsc/viewVersionPage?versionID=26965) where the operator is listed as **SUSE Ready**
- `docs/drivers/precompiled-driver.md` — SLES entries in the osImage→OS and tag-format reference tables

## Notes
- Support declarations use SUSE's catalog wording ("SLES 15 / 16"); the precompiled-driver table keeps the exact `SP7` / `16.0` osImage strings since that documents the literal `osImage` a node reports and how KMM parses it.
- `ROCm/main` already carries this content; this PR brings the `release-v1.5.1` GA docs in line.

## Test plan
- [ ] Docs build / spellcheck passes ("SUSE" already appears in existing docs; URLs excluded from spellcheck)
- [ ] RTD preview shows the SLES rows in the support matrix