### PR TITLE
docs: fix broken Red Hat links in OpenShift air-gapped guide

### DIFF
--- a/docs/specialized_networks/airgapped-install-openshift.md
+++ b/docs/specialized_networks/airgapped-install-openshift.md
@@ -5,7 +5,7 @@ This guide explains how to install the AMD GPU Operator in an air-gapped environ
 ## Prerequisites
 
 - OpenShift 4.16+
-- Users should have followed the [OpenShift Official Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/disconnected_environments/mirroring-in-disconnected-environments) to install the air-gapped cluster and set up a Mirror Registry.
+- Users should have followed the [OpenShift Official Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/disconnected_environments/index) to install the air-gapped cluster and set up a Mirror Registry.
 
 ![Air-gapped Installation Diagram](../_static/ocp_airgapped.png)
 
@@ -21,7 +21,7 @@ Here is an example `ImageSetConfiguration` for mirroring the required catalogs a
 1. The following `ImageSetConfiguration` file is an incomplete example.
 2. Users must configure the `storageConfig` section for either directly pushing artifacts to the mirror container registry or saving to local file storage.
 3. Users may merge the `mirror` section of this example with their own `ImageSetConfiguration`.
-4. Detailed explanation of `ImageSetConfiguration` can be found in the [OpenShift official documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/disconnected_environments/mirroring-in-disconnected-environments#using-oc-mirror_about-installing-oc-mirror-v2).
+4. Detailed explanation of `ImageSetConfiguration` can be found in the [OpenShift official documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/disconnected_environments/about-installing-oc-mirror-v2#oc-mirror-building-image-set-config-v2_about-installing-oc-mirror-v2).
 5. When mirroring the source image `docker.io/rocm/amdgpu-driver`, we strongly recommend making it accessible without requiring image pull secrets. If image pull secrets are required for pulling the source image, refer to the notes in [Driver Installation](../drivers/installation.md#install-out-of-tree-amd-gpu-drivers-with-operator) to configure the pull secret.
 ```
 


### PR DESCRIPTION
Backport of #644 to `release-v1.5.1`. The same two broken links are present on this branch, at the same line numbers.

Both Red Hat documentation links in `docs/specialized_networks/airgapped-install-openshift.md` currently return **HTTP 404**.

## Root cause

The chapter slug `mirroring-in-disconnected-environments` only ever existed in OCP **4.17**. Red Hat removed it in 4.18 and it has stayed gone:

| OCP version | `mirroring-in-disconnected-environments` |
|---|---|
| 4.17 | 200 |
| 4.18 – 4.22 | **404** |

The links were written against 4.17-era docs but pinned to the `4.19` path, so they were broken from the moment they landed.

## Fix

Point both links at the `latest` alias, which redirects to the current OCP release (4.22 today). This stops the links rotting when Red Hat renames a chapter or retires a version.

| Line | Target | Rationale |
|---|---|---|
| 8 | `.../latest/html/disconnected_environments/index` | The guide-level index is the most stable target available — it survived the chapter renames and resolves on 4.17 through 4.22. |
| 24 | `.../latest/html/disconnected_environments/about-installing-oc-mirror-v2#oc-mirror-building-image-set-config-v2_about-installing-oc-mirror-v2` | The oc-mirror plugin v2 chapter slug has been stable since 4.16, and the anchor lands on §5.4.1 "Creating the image set configuration" — exactly what the sentence promises. |

Note the guide itself was also renamed at 4.17 (`disconnected_installation_mirroring` → `disconnected_environments`), so no single URL covers the full "OpenShift 4.16+" range this guide claims to support. `latest` is the best available compromise and matches the "adjust the OpenShift version if needed" tone already used in the file's YAML comments.

## Validation

Cherry-picked from #644; applied cleanly with no conflicts. Both replacement URLs re-verified with `curl -L` on this branch:

```
.../latest/html/disconnected_environments/index
   -> 200  final: .../4.22/html/disconnected_environments/index

.../latest/html/disconnected_environments/about-installing-oc-mirror-v2#oc-mirror-building-image-set-config-v2_...
   -> 200  final: .../4.22/html/disconnected_environments/about-installing-oc-mirror-v2
```

The anchor id `oc-mirror-building-image-set-config-v2_about-installing-oc-mirror-v2` was confirmed present in the rendered 4.22 page HTML.

## Risk / rollback

Documentation-only; 2 lines changed in 1 file. No code, config, or manifest impact. Revert the commit to roll back.